### PR TITLE
Add hint that chrome is a requirement for bundesanzeiger

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ print(data["Adresse"][0])
 ### Bundesanzeiger
 Get financial reports for all german companies that are reporting to Bundesanzeiger.
 
+*Please note: For now [Google Chrome](https://www.google.com/chrome/) is required in order to use the Bundesanzeiger API. Please feel free to add [support for other browsers](https://github.com/SergeyPirogov/webdriver_manager).*
+
 ```python
 from deutschland import Bundesanzeiger
 ba = Bundesanzeiger()


### PR DESCRIPTION
I wanted to give the Bundesanzeiger API a try, but don't have Chrome installed, so I got this traceback:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/acat/tmp/deutscheland/env/lib64/python3.9/site-packages/deutschland/bundesanzeiger/bundesanzeiger.py", line 46, in __init__
    self.driver = webdriver.Chrome(ChromeDriverManager().install(), options=options)
  ...
    raise ValueError(f'Could not get version for Chrome with this command: {cmd}')
ValueError: Could not get version for Chrome with this command: google-chrome --version || google-chrome-stable --version

```

As I'm not a _real_ Python developer who can just fix this by adding support for other browsers and as I don't want to install Chrome, I decided to fix the README by adding a little hint so that other people at least know, that Chrome is required.