### PR TITLE
Füge "Suche nach Firmen" hinzu.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,7 @@ dmypy.json
 cython_debug/
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij,python
+
+# VSCode
+launch.json
+settings.json

--- a/deutschland/handelsregister/handelsregister.py
+++ b/deutschland/handelsregister/handelsregister.py
@@ -132,7 +132,7 @@ class Handelsregister:
 
         for code in counties:
             if code not in self.VALID_COUNTY_CODES:
-                raise f"{code} is not a valid county code."
+                raise Exception(f"{code} is not a valid county code.")
 
             search_params[f"bundesland{code}"] = "on"
 
@@ -213,5 +213,5 @@ class Handelsregister:
 
 if __name__ == "__main__":
     hr = Handelsregister()
-    res = hr.search({"ort": "Köln", "ergebnisseProSeite": 10}, ["NW"])
+    res = hr.search({"ort": "Köln", "ergebnisseProSeite": 10}, ["AB"])
     print(res)

--- a/deutschland/handelsregister/handelsregister.py
+++ b/deutschland/handelsregister/handelsregister.py
@@ -58,7 +58,7 @@ class Handelsregister:
         "postleitzahl": None,
         "ort": None,
         "strasse": None,
-        "ergebnisseProSeite": "100",
+        "ergebnisseProSeite": "10",
         "btnSuche": "Suchen",
     }
 
@@ -83,9 +83,9 @@ class Handelsregister:
         results = []
         next_entry = {}
 
-        # Skip the first row, which is only a header
+        # Skip the first row, which is the header row
         for tr in trs[1:]:
-            if tr.find("td", class_="RegPortErg_AZ") is not None:
+            if tr.find("td", class_="RegPortErg_AZ"):
                 data = self.__extract_county_court_and_registration(tr)
 
                 # Save the current entry since we reached the next entry
@@ -94,6 +94,9 @@ class Handelsregister:
                     results.append(next_entry.copy())
 
                 next_entry = data
+            elif tr.find("td", class_="RegPortErg_FirmaKopf"):
+                data = self.__extract_name_location_and_state(tr)
+                next_entry.update(data)
 
         return results
 
@@ -112,6 +115,14 @@ class Handelsregister:
             "registration_type": reg_type,
             "registration_number": reg_num,
         }
+
+    def __extract_name_location_and_state(self, row):
+        tds = row.find_all("td")
+        name = tds[1].text.strip()
+        location = tds[2].text.strip()
+        state = tds[3].text.strip()
+
+        return {"company_name": name, "location": location, "state": state}
 
 
 if __name__ == "__main__":

--- a/deutschland/handelsregister/handelsregister.py
+++ b/deutschland/handelsregister/handelsregister.py
@@ -97,6 +97,9 @@ class Handelsregister:
             elif tr.find("td", class_="RegPortErg_FirmaKopf"):
                 data = self.__extract_name_location_and_state(tr)
                 next_entry.update(data)
+            elif tr.find("td", class_="RegPortErg_HistorieZn"):
+                data = self.__extract_history(tr)
+                next_entry.setdefault("history", []).append(data)
 
         return results
 
@@ -123,6 +126,17 @@ class Handelsregister:
         state = tds[3].text.strip()
 
         return {"company_name": name, "location": location, "state": state}
+
+    def __extract_history(self, row):
+        tds = row.find_all("td")
+        [position, historical_name] = tds[1].text.strip().split(".) ", 1)
+        historical_location = tds[2].text.strip().split(".) ", 1)[1]
+
+        return {
+            "position": position,
+            "historical_name": historical_name,
+            "historical_location": historical_location,
+        }
 
 
 if __name__ == "__main__":

--- a/deutschland/handelsregister/handelsregister.py
+++ b/deutschland/handelsregister/handelsregister.py
@@ -1,0 +1,120 @@
+import requests
+import re
+
+from bs4 import BeautifulSoup
+
+
+class Handelsregister:
+    SEARCH_URL = "https://www.handelsregister.de/rp_web/mask.do?Typ=e"
+
+    REQUEST_HEADERS = {
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "Cache-Control": "max-age=0",
+        "Connection": "keep-alive",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "DNT": "1",
+        "Host": "www.handelsregister.de",
+        "Origin": "https://www.handelsregister.de",
+        "Referer": "https://www.handelsregister.de/rp_web/mask.do?Typ=e",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua": '"Chromium";v="92", " Not A;Brand";v="99", "Google Chrome";v="92"',
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "same-origin",
+        "Sec-Fetch-User": "?1",
+        "sec-gpc": "1",
+        "Upgrade-Insecure-Requests": "1",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36",
+    }
+
+    DEFAULT_FORM_DATA = {
+        "bundeslandBW": "on",
+        "bundeslandBY": "on",
+        "bundeslandBE": "on",
+        "bundeslandBR": "on",
+        "bundeslandHB": "on",
+        "bundeslandHH": "on",
+        "bundeslandHE": "on",
+        "bundeslandMV": "on",
+        "bundeslandNI": "on",
+        "bundeslandNW": "on",
+        "bundeslandRP": "on",
+        "bundeslandSL": "on",
+        "bundeslandSN": "on",
+        "bundeslandST": "on",
+        "bundeslandSH": "on",
+        "bundeslandTH": "on",
+        "schlagwoerter": None,
+        "schlagwortOptionen": 2,
+        "suchOptionenAehnlich": False,
+        "niederlassung": None,
+        "suchOptionenGeloescht": False,
+        "suchOptionenNurZNneuenRechts": False,
+        "suchTyp": "e",
+        "registerArt": None,
+        "registerNummer": None,
+        "registergericht": None,
+        "rechtsform": None,
+        "postleitzahl": None,
+        "ort": None,
+        "strasse": None,
+        "ergebnisseProSeite": "100",
+        "btnSuche": "Suchen",
+    }
+
+    def search(self, params={}):
+        search_params = {**self.DEFAULT_FORM_DATA, **params}
+        response = requests.post(
+            self.SEARCH_URL, data=search_params, headers=self.REQUEST_HEADERS
+        )
+        if response.status_code != 200:
+            return None
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        return self.__find_entries(soup)
+
+    def __find_entries(self, soup):
+        table = soup.find("table", class_="RegPortErg")
+        if table is None:
+            return []
+
+        trs = table.find_all("tr")
+
+        results = []
+        next_entry = {}
+
+        # Skip the first row, which is only a header
+        for tr in trs[1:]:
+            if tr.find("td", class_="RegPortErg_AZ") is not None:
+                data = self.__extract_county_court_and_registration(tr)
+
+                # Save the current entry since we reached the next entry
+                # demarcated by the .RegPortErg_AZ table cell.
+                if next_entry:
+                    results.append(next_entry.copy())
+
+                next_entry = data
+
+        return results
+
+    def __extract_county_court_and_registration(self, row):
+        td = row.find("td", class_="RegPortErg_AZ")
+        county = td.contents[2].strip()
+        court_and_registration = (
+            td.contents[3].text.strip().replace("\n", " ").replace("\t", "").split()
+        )
+        court = " ".join(court_and_registration[:-2])
+        [reg_type, reg_num] = court_and_registration[-2:]
+
+        return {
+            "county": county,
+            "court": court,
+            "registration_type": reg_type,
+            "registration_number": reg_num,
+        }
+
+
+if __name__ == "__main__":
+    hr = Handelsregister()
+    foo = hr.search({"ort": "Köln"})
+    print(foo)

--- a/deutschland/handelsregister/params.md
+++ b/deutschland/handelsregister/params.md
@@ -1,0 +1,32 @@
+## Possible Values for 'rechtsform'
+| Value | Description                   |
+| ----- | ----------------------------- |
+| 1     | Aktiengesellschaft            |
+| 40    | Anstalt öffentlichen Rechts   |
+| 46    | Bergrechtliche Gewerkschaft   |
+| 2     | eingetragene Genossenschaft   |
+| 3     | eingetragener Verein          |
+| 4     | Einzelkauffrau                |
+| 5     | Einzelkaufmann                |
+| 55    | Einzelkaufmann                |
+| 6     | Europäische                   |
+| 49    | Europäische Genossenschaft    |
+| 7     | Europäische wirtschaftliche   |
+| 8     | Gesellschaft mit beschränkter |
+| 9     | HRA Juristische Person        |
+| 53    | HRA sonstige Rechtsformen     |
+| 10    | Kommanditgesellschaft         |
+| 11    | Kommanditgesellschaft auf     |
+| 48    | Körperschaft öffentlichen     |
+| 12    | Offene Handelsgesellschaft    |
+| 13    | Partnerschaft                 |
+| 56    | Partnerschaftsgesellschaft    |
+| 14    | Rechtsform ausländischen      |
+| 15    | Rechtsform ausländischen      |
+| 16    | Rechtsform ausländischen      |
+| 17    | Rechtsform ausländischen      |
+| 18    | Seerechtliche Gesellschaft    |
+| 54    | Sonstige juristische Person   |
+| 52    | Stiftung öffentlichen         |
+| 51    | Stiftung privaten Rechts      |
+| 19    | Versicherungsverein auf       |


### PR DESCRIPTION
Man man, wat'n Krampf das Ganze. Aber gut. Hier ist er, der Such-Gerät.

Schön ist das Ganze zwar nicht, aber hier ist ein Vorschlag für die erste Funktionalität des Handelsregisters: 

**Die Suche nach Firmen im Handelsregister**

Ich habe davon abgesehen jeden Suchparameter aus dem Deutschen ins Englische zu übersetzen und biete stattdessen die Möglichkeit an, jeden Parameter in einem Dict nach Belieben zu setzen und damit den Default zu überschreiben. Ich habe versucht die Parameter so gut es geht zu dokumentieren. Außerdem kann man die Bundesländer als gesonderten Parameter als Liste angeben. 

Ein große Einschränkung hat das Ganze allerdings noch: Pagination wird noch nicht unterstützt. Sprich, bisher werden nur die ersten 100 Ergebnisse zurückgegeben. Ich wollte erstmal diesen PR anbieten, bevor ich mich mit der Pagination weiter beschäftige.

Ich bitte einmal um Feedback. Bitte auch über die Entscheidung, ob diese Funktionalität bereits gemerged werden kann, oder ob wir später alle Funktionalitäten (sprich auch Bekanntmachungen und Veröffentlichungen) zusammen mergen bzw. releasen möchten.

Ebenfalls habe ich die Docs vorerst in reStructuredText-Format geschrieben. Bitte auch hier einmal entscheiden, welches Format gewünscht ist.
