### PR TITLE
Add Configuration for Proxies

### DIFF
--- a/deutschland/__init__.py
+++ b/deutschland/__init__.py
@@ -1,6 +1,7 @@
-from .geo import Geo
-from .bundesanzeiger.bundesanzeiger import Bundesanzeiger
-from .handelsregister.handelsregister import Handelsregister
 from .config import Config
 
 module_config = Config()
+
+from .geo import Geo
+from .bundesanzeiger.bundesanzeiger import Bundesanzeiger
+from .handelsregister.handelsregister import Handelsregister

--- a/deutschland/__init__.py
+++ b/deutschland/__init__.py
@@ -2,3 +2,5 @@ from .geo import Geo
 from .bundesanzeiger.bundesanzeiger import Bundesanzeiger
 from .handelsregister.handelsregister import Handelsregister
 from .config import Config
+
+module_config = Config()

--- a/deutschland/__init__.py
+++ b/deutschland/__init__.py
@@ -1,3 +1,4 @@
 from .geo import Geo
 from .bundesanzeiger.bundesanzeiger import Bundesanzeiger
 from .handelsregister.handelsregister import Handelsregister
+from .config import Config

--- a/deutschland/bundesanzeiger/bundesanzeiger.py
+++ b/deutschland/bundesanzeiger/bundesanzeiger.py
@@ -5,7 +5,7 @@ import dateparser
 
 from bs4 import BeautifulSoup
 
-from deutschland import Config
+from deutschland import Config, module_config
 
 
 class Report:
@@ -31,10 +31,13 @@ class Bundesanzeiger:
     __slots__ = ["session", "model", "captcha_callback", "_config"]
 
     def __init__(self, on_captach_callback=None, config: Config = None):
-        self._config = config
+        if config is None:
+            self._config = module_config
+        else:
+            self._config = config
 
         self.session = requests.Session()
-        if self._config is not None and self._config.proxy_config is not None:
+        if self._config.proxy_config is not None:
             self.session.proxies.update(self._config.proxy_config)
         if on_captach_callback:
             self.callback = on_captach_callback

--- a/deutschland/bundesanzeiger/bundesanzeiger.py
+++ b/deutschland/bundesanzeiger/bundesanzeiger.py
@@ -5,6 +5,8 @@ import dateparser
 
 from bs4 import BeautifulSoup
 
+from deutschland import Config
+
 
 class Report:
     __slots__ = ["date", "name", "content_url", "company", "report"]
@@ -26,10 +28,14 @@ class Report:
 
 
 class Bundesanzeiger:
-    __slots__ = ["session", "model", "captcha_callback"]
+    __slots__ = ["session", "model", "captcha_callback", "_config"]
 
-    def __init__(self, on_captach_callback=None):
+    def __init__(self, on_captach_callback=None, config: Config = None):
+        self._config = config
+
         self.session = requests.Session()
+        if self._config is not None and self._config.proxy_config is not None:
+            self.session.proxies.update(self._config.proxy_config)
         if on_captach_callback:
             self.callback = on_captach_callback
         else:

--- a/deutschland/config.py
+++ b/deutschland/config.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+
+class Config:
+    proxy_config = None
+
+    def __init__(self, proxies: Dict[str, str] = None):
+        if proxies is not None and isinstance(proxies, dict):
+            self.proxy_config = proxies
+
+    def set_proxy(self, http_proxy: str, https_proxy: str):
+        if self.proxy_config is None:
+            self.proxy_config = {}
+        self.proxy_config.update({"http": http_proxy, "https": https_proxy})

--- a/deutschland/geo.py
+++ b/deutschland/geo.py
@@ -3,7 +3,7 @@ from typing import List, Dict
 import requests
 import mapbox_vector_tile
 
-from deutschland import Config
+from deutschland import Config, module_config
 
 
 class Geo:
@@ -12,7 +12,10 @@ class Geo:
     MVT_EXTENT = 4096
 
     def __init__(self, config: Config = None):
-        self._config = config
+        if config is None:
+            self._config = module_config
+        else:
+            self._config = config
 
     def __deg2num(self, lat_deg, lon_deg, zoom):
         lat_rad = math.radians(lat_deg)
@@ -49,13 +52,14 @@ class Geo:
         :param top_right: the top right [lat, lon] coordinates (e.g. [47.23,5.53])
         :param bottom_left: the bottom left [lat, lon] coordinates (e.g. [54.96,15.38])
         :param proxies: proxies to use for this call (e.g. {'http': 'http://10.10.1.10:3128',
-            'https': 'http://10.10.1.10:1080'} ) overwrites proxies from config
+        'https': 'http://10.10.1.10:1080'}) overwrites proxies from config
         :return:
         """
 
         tr = self.__deg2num(top_right[0], top_right[1], self.LEVEL)
         bl = self.__deg2num(bottom_left[0], bottom_left[1], self.LEVEL)
 
+        # parameter has higher priority than member
         if proxies is None:
             if self._config is not None and self._config.proxy_config is not None:
                 proxies = self._config.proxy_config

--- a/deutschland/geo.py
+++ b/deutschland/geo.py
@@ -46,7 +46,12 @@ class Geo:
 
         return project(px, py)
 
-    def fetch(self, top_right: List[float], bottom_left: List[float], proxies: Dict[str, str] = None):
+    def fetch(
+        self,
+        top_right: List[float],
+        bottom_left: List[float],
+        proxies: Dict[str, str] = None,
+    ):
         """
         fetch the geo data inside the area selected
         :param top_right: the top right [lat, lon] coordinates (e.g. [47.23,5.53])

--- a/deutschland/handelsregister/handelsregister.py
+++ b/deutschland/handelsregister/handelsregister.py
@@ -1,11 +1,18 @@
 from datetime import date
 
+from deutschland import module_config, Config
 from deutschland.handelsregister.registrations import Registrations
 from deutschland.handelsregister.publications import Publications
 from deutschland.handelsregister.publication_detail import PublicationDetail
 
 
 class Handelsregister:
+    def __init__(self, config: Config = None):
+        if config is None:
+            self._config = module_config
+        else:
+            self._config = config
+
     def search(
         self,
         keywords: str = None,
@@ -95,7 +102,7 @@ class Handelsregister:
             "strasse": street,
             "ergebnisseProSeite": limit,
         }
-        r = Registrations()
+        r = Registrations(self._config)
         return r.search_with_raw_params(params)
 
     def search_publications(
@@ -245,7 +252,7 @@ class Handelsregister:
             "order": order_by,
         }
 
-        p = Publications()
+        p = Publications(self._config)
         return p.search_with_raw_params(params)
 
     def get_publication_detail(self, publication_id: str, county_code: str):
@@ -278,7 +285,7 @@ class Handelsregister:
           sh: Schleswig-Holstein
           th: Thüringen
         """
-        pd = PublicationDetail()
+        pd = PublicationDetail(self._config)
         return pd.get_detail(publication_id=publication_id, county_code=county_code)
 
 

--- a/deutschland/handelsregister/publication_detail.py
+++ b/deutschland/handelsregister/publication_detail.py
@@ -1,10 +1,20 @@
 from datetime import datetime
+from typing import Dict
+
 from bs4 import BeautifulSoup
 import dateparser
 import requests
 
+from deutschland import module_config, Config
+
 
 class PublicationDetail:
+    def __init__(self, config: Config = None):
+        if config is None:
+            self._config = module_config
+        else:
+            self._config = config
+
     DETAIL_URL = "https://www.handelsregisterbekanntmachungen.de/skripte/hrb.php?rb_id={}&land_abk={}"
 
     REQUEST_HEADERS = {
@@ -27,7 +37,9 @@ class PublicationDetail:
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36",
     }
 
-    def get_detail(self, publication_id: str, county_code: str):
+    def get_detail(
+        self, publication_id: str, county_code: str, proxies: Dict[str, str] = None
+    ):
         """
         Get the details of a publication with its identifier and county code.
 
@@ -57,8 +69,16 @@ class PublicationDetail:
           sh: Schleswig-Holstein
           th: Thüringen
         """
+
+        # parameter has higher priority than member
+        if proxies is None:
+            if self._config is not None and self._config.proxy_config is not None:
+                proxies = self._config.proxy_config
+
         request_url = self.DETAIL_URL.format(publication_id, county_code)
-        response = requests.get(request_url, headers=self.REQUEST_HEADERS)
+        response = requests.get(
+            request_url, headers=self.REQUEST_HEADERS, proxies=proxies
+        )
 
         if response.status_code != 200:
             return None

--- a/deutschland/handelsregister/publications.py
+++ b/deutschland/handelsregister/publications.py
@@ -5,6 +5,8 @@ from bs4 import BeautifulSoup
 import dateparser
 import requests
 
+from deutschland import module_config
+
 
 class Publications:
     REQUEST_HEADERS = {
@@ -162,7 +164,7 @@ class Publications:
         search_params = {**self.DEFAULT_FORM_DATA, **params}
 
         response = requests.post(
-            self.SEARCH_URL, data=search_params, headers=self.REQUEST_HEADERS
+            self.SEARCH_URL, data=search_params, headers=self.REQUEST_HEADERS, proxies=module_config.proxy_config
         )
         if response.status_code != 200:
             return None

--- a/deutschland/handelsregister/publications.py
+++ b/deutschland/handelsregister/publications.py
@@ -1,7 +1,6 @@
 from typing import Dict
 from bs4 import BeautifulSoup
 
-
 import dateparser
 import requests
 
@@ -164,7 +163,10 @@ class Publications:
         search_params = {**self.DEFAULT_FORM_DATA, **params}
 
         response = requests.post(
-            self.SEARCH_URL, data=search_params, headers=self.REQUEST_HEADERS, proxies=module_config.proxy_config
+            self.SEARCH_URL,
+            data=search_params,
+            headers=self.REQUEST_HEADERS,
+            proxies=module_config.proxy_config,
         )
         if response.status_code != 200:
             return None

--- a/deutschland/handelsregister/publications.py
+++ b/deutschland/handelsregister/publications.py
@@ -4,10 +4,16 @@ from bs4 import BeautifulSoup
 import dateparser
 import requests
 
-from deutschland import module_config
+from deutschland import module_config, Config
 
 
 class Publications:
+    def __init__(self, config: Config = None):
+        if config is None:
+            self._config = module_config
+        else:
+            self._config = config
+
     REQUEST_HEADERS = {
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
         "Accept-Encoding": "gzip, deflate, br",
@@ -52,7 +58,9 @@ class Publications:
         "button": "Suche starten",
     }
 
-    def search_with_raw_params(self, params: Dict[str, str] = {}):
+    def search_with_raw_params(
+        self, params: Dict[str, str] = {}, proxies: Dict[str, str] = None
+    ):
         """
         Searches the Publications of the Handelsregister with a given dict of parameters.
 
@@ -160,13 +168,19 @@ class Publications:
           3 : Order by creation date of publication
           4 : Order by publication date
         """
+
+        # parameter has higher priority than member
+        if proxies is None:
+            if self._config is not None and self._config.proxy_config is not None:
+                proxies = self._config.proxy_config
+
         search_params = {**self.DEFAULT_FORM_DATA, **params}
 
         response = requests.post(
             self.SEARCH_URL,
             data=search_params,
             headers=self.REQUEST_HEADERS,
-            proxies=module_config.proxy_config,
+            proxies=proxies,
         )
         if response.status_code != 200:
             return None

--- a/deutschland/handelsregister/registrations.py
+++ b/deutschland/handelsregister/registrations.py
@@ -3,10 +3,16 @@ import requests
 
 from bs4 import BeautifulSoup
 
-from deutschland import module_config
+from deutschland import module_config, Config
 
 
 class Registrations:
+    def __init__(self, config: Config = None):
+        if config is None:
+            self._config = module_config
+        else:
+            self._config = config
+
     REQUEST_HEADERS = {
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
         "Cache-Control": "max-age=0",
@@ -48,7 +54,9 @@ class Registrations:
         "btnSuche": "Suchen",
     }
 
-    def search_with_raw_params(self, params: Dict[str, str] = {}):
+    def search_with_raw_params(
+        self, params: Dict[str, str] = {}, proxies: Dict[str, str] = None
+    ):
         """
         Searches the Handelsregister with a given dict of parameters.
 
@@ -115,13 +123,19 @@ class Registrations:
         ergebnisseProSeite : int
           How many matches to return. Defaults to 100.
         """
+
+        # parameter has higher priority than member
+        if proxies is None:
+            if self._config is not None and self._config.proxy_config is not None:
+                proxies = self._config.proxy_config
+
         search_params = {**self.DEFAULT_FORM_DATA, **params}
 
         response = requests.post(
             self.SEARCH_URL,
             data=search_params,
             headers=self.REQUEST_HEADERS,
-            proxies=module_config.proxy_config,
+            proxies=proxies,
         )
         if response.status_code != 200:
             return None

--- a/deutschland/handelsregister/registrations.py
+++ b/deutschland/handelsregister/registrations.py
@@ -118,7 +118,10 @@ class Registrations:
         search_params = {**self.DEFAULT_FORM_DATA, **params}
 
         response = requests.post(
-            self.SEARCH_URL, data=search_params, headers=self.REQUEST_HEADERS, proxies=module_config.proxy_config
+            self.SEARCH_URL,
+            data=search_params,
+            headers=self.REQUEST_HEADERS,
+            proxies=module_config.proxy_config,
         )
         if response.status_code != 200:
             return None

--- a/deutschland/handelsregister/registrations.py
+++ b/deutschland/handelsregister/registrations.py
@@ -3,6 +3,8 @@ import requests
 
 from bs4 import BeautifulSoup
 
+from deutschland import module_config
+
 
 class Registrations:
     REQUEST_HEADERS = {
@@ -116,7 +118,7 @@ class Registrations:
         search_params = {**self.DEFAULT_FORM_DATA, **params}
 
         response = requests.post(
-            self.SEARCH_URL, data=search_params, headers=self.REQUEST_HEADERS
+            self.SEARCH_URL, data=search_params, headers=self.REQUEST_HEADERS, proxies=module_config.proxy_config
         )
         if response.status_code != 200:
             return None


### PR DESCRIPTION
## Changes

Added general configuration, currently used to configure proxies for `requests`.
All methods using `requests.HTTP-METHOD` now have an additional optional paramter to provide a proxy-config.
If no parameter is provided try to use a optional class-wide proxy-configuration. 
If this fails a module-wide Config-Object `module_config` will be used.
This will make it easy to provide a global config but also to change proxies for every call.
`deutschland.Bundesanzeiger` uses `requests.Session` and therefore the proxy configuration is set for the whole session.

## Example Code

```python
from deutschland import Geo, Config, module_config

# set proxies in modue-wide config
module_config.set_proxy('http://10.10.1.10:3128', 'https://10.10.1.10:1080')


# class-wide config
local_config = Config({'http': 'http://10.10.1.10:3128', 'https': 'https://10.10.1.10:1080'})
geo = Geo(local_config)    # Overwrite global config and use local_config for all requests
...
# proxies only for the next call
proxies = {'http': 'http://10.10.1.10:3128', 'https': 'https://10.10.1.10:1080'}
data = geo.fetch([52.50876180448243, 13.359631043007212], 
                          [52.530116236589244, 13.426532801586827],
                          proxies)

```

<details>
  <summary>Addressed Issues</summary>
  
  - fixes #1
</details>