### PR TITLE
Integration of voting results from Bundeswahlleiter

### DIFF
--- a/deutschland/__init__.py
+++ b/deutschland/__init__.py
@@ -7,3 +7,4 @@ from .bundesanzeiger.bundesanzeiger import Bundesanzeiger
 from .handelsregister.handelsregister import Handelsregister
 from .lebensmittelwarnung.lebensmittelwarnung import Lebensmittelwarnung
 from .bundesnetzagentur import *
+from .bundeswahlleiter.bundeswahlleiter import Bundeswahlleiter

--- a/deutschland/bundeswahlleiter/bundeswahlleiter.py
+++ b/deutschland/bundeswahlleiter/bundeswahlleiter.py
@@ -1,0 +1,66 @@
+import requests
+import csv
+import io
+import zipfile
+import pandas
+import numpy as np
+from itertools import repeat, zip_longest
+from more_itertools import take, consume
+
+class Bundeswahlleiter:
+    HISTORICAL_RESULTS_URL = "https://www.bundeswahlleiter.de/dam/jcr/ce2d2b6a-f211-4355-8eea-355c98cd4e47/btw_kerg.zip"
+    OPEN_DATA_URL = "https://www.bundeswahlleiter.de/bundestagswahlen/2021/ergebnisse/opendata/csv/kerg.csv"
+
+    def load_results(self, year):
+        if year < 2021:
+            buffer = self._load_historical_year(year)
+        else:
+            buffer = self._load_open_data()
+        return self._parse_btw_results(buffer, year)
+
+    def _parse_btw_results(self, f, year):
+        encoding = "windows-1252" if year <= 2013 else "utf8"
+        reader = csv.reader(io.TextIOWrapper(io.BytesIO(f), encoding=encoding), delimiter=";")
+        line_skip = 5 if year <= 2017 else 2
+        consume(reader, line_skip)
+        header_lines = take(3, reader)
+        headers =  list(zip_longest(*header_lines, fillvalue=""))
+        for i in range(1, len(headers)):
+            # extend implicit headers
+            if not headers[i][0] and headers[i] != ("", "", ""):
+                headers[i] = (headers[i - 1][0], headers[i][1] or headers[i - 1][1], headers[i][2])
+        # first three columns are not named consistently
+        headers[0] = ("id", "", "")
+        headers[1] = ("name", "", "")
+        headers[2] = ("parent", "", "")
+        index = pandas.MultiIndex.from_tuples(headers)
+        districts = pandas.DataFrame.from_records(list(reader), columns=index)
+        contains_last_results = any(map(lambda x: "Vorperiode" in x, headers))
+        if contains_last_results:
+            districts.drop("Vorperiode", level=2, inplace=True, axis=1)
+        if ("", "", "") in headers:
+            districts.drop(("", "", ""), inplace=True, axis=1)
+        districts = districts[~districts["id"].isin(["", None])]
+        districts[districts == ""] = "0"
+        # columns from index 3 on contain vote counts
+        districts = districts.astype(dict(zip(districts.columns[3:], repeat(np.uint64))))
+        districts = districts.droplevel(2, axis=1)
+        return districts
+
+    def _load_historical_year(self, year):
+        with zipfile.ZipFile(io.BytesIO(self._load_historical())) as zfile:
+            filename = f"btw{year}_kerg.csv"
+            if filename not in map(lambda f: f.filename, zfile.infolist()):
+                raise RuntimeError(f"year {year} not available")
+            with zfile.open(filename, "r") as f:
+                return f.read()
+
+    def _load_historical(self):
+        resp = requests.get(self.HISTORICAL_RESULTS_URL)
+        resp.raise_for_status()
+        return resp.content
+        
+    def _load_open_data(self):
+        resp = requests.get(self.OPEN_DATA_URL)
+        resp.raise_for_status()
+        return resp.content

--- a/poetry.lock
+++ b/poetry.lock
@@ -433,6 +433,14 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 testing = ["coverage", "pyyaml"]
 
 [[package]]
+name = "more-itertools"
+version = "8.10.0"
+description = "More routines for operating on iterables, beyond itertools"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -486,6 +494,22 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
+
+[[package]]
+name = "pandas"
+version = "1.3.3"
+description = "Powerful data structures for data analysis, time series, and statistics"
+category = "main"
+optional = false
+python-versions = ">=3.7.1"
+
+[package.dependencies]
+numpy = ">=1.17.3"
+python-dateutil = ">=2.7.3"
+pytz = ">=2017.3"
+
+[package.extras]
+test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
 
 [[package]]
 name = "pathspec"
@@ -918,8 +942,8 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "9befdf4072bf4d4df5ab69bfe3f6c61b4b8720da6100a47881eddf5b75876db6"
+python-versions = "^3.7.1"
+content-hash = "180ae98b46a6e80a8874f5021ae47e76027cd01c1658728011bf1db0b947067a"
 
 [metadata.files]
 absl-py = [
@@ -1162,6 +1186,10 @@ markdown = [
     {file = "Markdown-3.3.4-py3-none-any.whl", hash = "sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c"},
     {file = "Markdown-3.3.4.tar.gz", hash = "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49"},
 ]
+more-itertools = [
+    {file = "more-itertools-8.10.0.tar.gz", hash = "sha256:1debcabeb1df793814859d64a81ad7cb10504c24349368ccf214c664c474f41f"},
+    {file = "more_itertools-8.10.0-py3-none-any.whl", hash = "sha256:56ddac45541718ba332db05f464bebfb0768110111affd27f66e0051f276fa43"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -1213,6 +1241,29 @@ opt-einsum = [
 packaging = [
     {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
     {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
+]
+pandas = [
+    {file = "pandas-1.3.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68408a39a54ebadb9014ee5a4fae27b2fe524317bc80adf56c9ac59e8f8ea431"},
+    {file = "pandas-1.3.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86b16b1b920c4cb27fdd65a2c20258bcd9c794be491290660722bb0ea765054d"},
+    {file = "pandas-1.3.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:37d63e78e87eb3791da7be4100a65da0383670c2b59e493d9e73098d7a879226"},
+    {file = "pandas-1.3.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53e2fb11f86f6253bb1df26e3aeab3bf2e000aaa32a953ec394571bec5dc6fd6"},
+    {file = "pandas-1.3.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7326b37de08d42dd3fff5b7ef7691d0fd0bf2428f4ba5a2bdc3b3247e9a52e4c"},
+    {file = "pandas-1.3.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed2f29b4da6f6ae7c68f4b3708d9d9e59fa89b2f9e87c2b64ce055cbd39f729e"},
+    {file = "pandas-1.3.3-cp37-cp37m-win32.whl", hash = "sha256:3f5020613c1d8e304840c34aeb171377dc755521bf5e69804991030c2a48aec3"},
+    {file = "pandas-1.3.3-cp37-cp37m-win_amd64.whl", hash = "sha256:c399200631db9bd9335d013ec7fce4edb98651035c249d532945c78ad453f23a"},
+    {file = "pandas-1.3.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a800df4e101b721e94d04c355e611863cc31887f24c0b019572e26518cbbcab6"},
+    {file = "pandas-1.3.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3334a5a9eeaca953b9db1b2b165dcdc5180b5011f3bec3a57a3580c9c22eae68"},
+    {file = "pandas-1.3.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49fd2889d8116d7acef0709e4c82b8560a8b22b0f77471391d12c27596e90267"},
+    {file = "pandas-1.3.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7557b39c8e86eb0543a17a002ac1ea0f38911c3c17095bc9350d0a65b32d801c"},
+    {file = "pandas-1.3.3-cp38-cp38-win32.whl", hash = "sha256:629138b7cf81a2e55aa29ce7b04c1cece20485271d1f6c469c6a0c03857db6a4"},
+    {file = "pandas-1.3.3-cp38-cp38-win_amd64.whl", hash = "sha256:45649503e167d45360aa7c52f18d1591a6d5c70d2f3a26bc90a3297a30ce9a66"},
+    {file = "pandas-1.3.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ebbed7312547a924df0cbe133ff1250eeb94cdff3c09a794dc991c5621c8c735"},
+    {file = "pandas-1.3.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9f1b54d7efc9df05320b14a48fb18686f781aa66cc7b47bb62fabfc67a0985c"},
+    {file = "pandas-1.3.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9bc59855598cb57f68fdabd4897d3ed2bc3a3b3bef7b868a0153c4cd03f3207"},
+    {file = "pandas-1.3.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4def2ef2fb7fcd62f2aa51bacb817ee9029e5c8efe42fe527ba21f6a3ddf1a9f"},
+    {file = "pandas-1.3.3-cp39-cp39-win32.whl", hash = "sha256:f7d84f321674c2f0f31887ee6d5755c54ca1ea5e144d6d54b3bbf566dd9ea0cc"},
+    {file = "pandas-1.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:e574c2637c9d27f322e911650b36e858c885702c5996eda8a5a60e35e6648cf2"},
+    {file = "pandas-1.3.3.tar.gz", hash = "sha256:272c8cb14aa9793eada6b1ebe81994616e647b5892a370c7135efb2924b701df"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/bundesAPI/deutschland"
 include = ["assets/model.h5"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.7.1"
 Shapely = "^1.7.1"
 mapbox-vector-tile = "^1.2.1"
 requests = "^2.26.0"
@@ -22,6 +22,8 @@ Pillow = "^8.3.1"
 beautifulsoup4 = "^4.9.3"
 lxml = "^4.6.3"
 pypresseportal = "^0.1"
+pandas = "^1.3.3"
+more-itertools = "^8.10.0"
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/bundesAPI/deutschland/issues"

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -2,6 +2,7 @@ import datetime
 from deutschland import Bundesanzeiger
 from deutschland import Handelsregister
 from deutschland import Rufzeichen
+from deutschland import Bundeswahlleiter
 
 from deutschland.handelsregister.registrations import Registrations
 
@@ -75,3 +76,13 @@ def test_callsign():
     rz = Rufzeichen()
     data = rz.get("DL*MIC")
     assert data["klasse"] == "A", "No valid callsign data returned"
+
+def test_bundeswahlleiter():
+    bwl = Bundeswahlleiter()
+    results1998 = bwl.load_results(1998)
+    results2017 = bwl.load_results(2017)
+    results2021 = bwl.load_results(2021)
+    # results contain rows for each Wahlkreis, Bundesland and the Bund
+    assert len(results1998) == 328 + 16 + 1
+    assert len(results2017) == 299 + 16 + 1
+    assert len(results2021) == 299 + 16 + 1


### PR DESCRIPTION
This PR deals with loading the results of Bundestagswahlen. It fetches the corresponding CSV file and parses them into usable pandas DataFrames. The column names are taken from the CSVs. This PR aims to close bundesAPI/sofortmassnahmen#35.

There are still some things to consider. The CSVs from the Bundeswahlleiter contain all electoral districts as well as the summed results for each Bundesland as well as a some over the whole country. These could be removed, because the information is implicit from the district results. Some column names could also be improved, for example, until 2017 there was a column Wähler which was renamed to Wählende in 2021, should these all be renamed to Wählende or would the english voter be easier to use? Also, the party names differ from year to year. In older results only the party short name was used, whereas in recent results the full name is used (SPD vs Sozialdemokratische Partei Deutschlands). If we would want to change the names to the short names, we would need a list of all the associations for all parties or at least all major parties. Also the ids for non-district rows are all over the place, I have to see how to normalize them.

Some examples how the data can be used:
```python
bwl = Bundeswahlleiter()
results2021[["name", "Sozialdemokratische Partei Deutschlands"]]
results2021[results2021["name"] == "Flensburg - Schleswig"]
```