### PR TITLE
Add notice about generated API-Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ presseportal = PresseportalApi("YOUR_KEY_HERE")
 stories = presseportal.get_stories()    
 ```
 
+## Auto-Generated API-Clients
+
 ### bundesrat
 For the detailed documentation of this API see [here](./docs/bundesrat/README.md)
 ### bundestag


### PR DESCRIPTION
Makes it more obvious that part of the code in this repository is autogenerated based on openapi-specs.
Maybe also add a notice at the beginning of the README