### PR TITLE
Some improvements to the test action

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -3,12 +3,12 @@ name: Run Python 🐍 tests
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- Test on Python 3.10 too
- Rename: build -> test
- If one Python version fails, don't cancel the other tests

I put the python version in quotes because the YAML parser otherwise interprets it as a number, and will think it's 3.10 (3,10 in German notation), which it will pass to actions as 3.1.