### PR TITLE
Add method to hash entry. Use it for key generation for return dict.

### DIFF
--- a/src/deutschland/bundesanzeiger/bundesanzeiger.py
+++ b/src/deutschland/bundesanzeiger/bundesanzeiger.py
@@ -4,6 +4,8 @@ import dateparser
 import numpy as np
 import requests
 from bs4 import BeautifulSoup
+import hashlib
+import json
 
 from deutschland.config import Config, module_config
 
@@ -25,6 +27,23 @@ class Report:
             "company": self.company,
             "report": self.report,
         }
+
+    def to_hash(self):
+            """MD5 hash of a the report."""
+
+            dhash = hashlib.md5()
+
+            entry = {
+                "date": self.date.isoformat(),
+                "name": self.name,
+                "company": self.company,
+                "report": self.report,
+            }
+
+            encoded = json.dumps(entry, sort_keys=True).encode('utf-8')
+            dhash.update(encoded)
+
+            return dhash.hexdigest()
 
 
 class Bundesanzeiger:
@@ -121,7 +140,10 @@ class Bundesanzeiger:
                 continue
 
             element.report = content_element.text
-            result[element.name] = element.to_dict()
+
+
+            result[element.to_hash()] = element.to_dict()
+
 
         return result
 

--- a/tests/bundesanzeiger/test_results.py
+++ b/tests/bundesanzeiger/test_results.py
@@ -5,3 +5,9 @@ def test_results_not_empty():
     ba = Bundesanzeiger()
     reports = ba.get_reports("Deutsches Zentrum für Luft- und Raumfahrt")
     assert len(reports) > 0
+
+def test_multiple_entries():
+    ba = Bundesanzeiger()
+    reports = ba.get_reports("DE000A0TGJ55")
+
+    assert len(reports) > 1


### PR DESCRIPTION
Use hash for return dict instead of names due to collisions in key names.