### PR TITLE
Bug fixed: registration_type changed from int to str

### DIFF
--- a/src/deutschland/handelsregister/handelsregister.py
+++ b/src/deutschland/handelsregister/handelsregister.py
@@ -21,7 +21,7 @@ class Handelsregister:
         head_office_location: str = None,
         include_deleted: bool = False,
         include_new_second_branches: bool = False,
-        registration_type: int = None,
+        registration_type: str = None,
         registration_number: str = None,
         court: str = None,
         legal_form: str = None,


### PR DESCRIPTION
Laut der Dokumentation und dem Skript registration.py muss das Feld `registration_type` den Datentyp `string` anstelle von `int` haben.