### PR TITLE
Adds dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot) 

One should use Dependabot to streamline dependency management, ensuring software projects stay up-to-date with automated updates and reducing the risk of vulnerabilities.