### PR TITLE
Add unit tests for Bundesanzeiger.__get_response()

### DIFF
--- a/tests/bundesanzeiger/test_connection.py
+++ b/tests/bundesanzeiger/test_connection.py
@@ -1,0 +1,18 @@
+import pytest
+from requests import Response
+from deutschland.bundesanzeiger import Bundesanzeiger
+
+
+def test_exception_on_invalid_http_code():
+    ba = Bundesanzeiger()
+    with pytest.raises(ConnectionError):
+        ba._Bundesanzeiger__get_response("https://httpstat.us/500")
+        ba._Bundesanzeiger__get_response("https://httpstat.us/503")
+        ba._Bundesanzeiger__get_response("https://httpstat.us/404")
+
+
+def test_get_response():
+    ba = Bundesanzeiger()
+    assert (
+        ba._Bundesanzeiger__get_response("https://httpstat.us/200").status_code == 200
+    )

--- a/tests/bundesanzeiger/test_connection.py
+++ b/tests/bundesanzeiger/test_connection.py
@@ -1,5 +1,4 @@
 import pytest
-from requests import Response
 from deutschland.bundesanzeiger import Bundesanzeiger
 
 


### PR DESCRIPTION
As suggested in #125:

- Add unit tests for Bundesanzeiger.__get_response() function