### PR TITLE
bundesanzeiger: allow fetching multiple pages for one company

### DIFF
--- a/src/deutschland/bundesanzeiger/bundesanzeiger.py
+++ b/src/deutschland/bundesanzeiger/bundesanzeiger.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 from io import BytesIO
+from urllib.parse import quote_plus
 
 import dateparser
 import numpy as np
@@ -223,7 +224,7 @@ class Bundesanzeiger:
         # go to the start page
         response = self.__get_response("https://www.bundesanzeiger.de/pub/de/start?0")
         # perform the search
-        search_url = f"https://www.bundesanzeiger.de/pub/de/start?0-2.-top%7Econtent%7Epanel-left%7Ecard-form=&fulltext={company_name}&area_select=&search_button=Suchen"
+        search_url = f"https://www.bundesanzeiger.de/pub/de/start?0-2.-top%7Econtent%7Epanel-left%7Ecard-form=&fulltext={quote_plus(company_name)}&area_select=&search_button=Suchen"
         return self.__generate_result(search_url, page_limit)
 
 

--- a/src/deutschland/bundesanzeiger/bundesanzeiger.py
+++ b/src/deutschland/bundesanzeiger/bundesanzeiger.py
@@ -114,7 +114,7 @@ class Bundesanzeiger:
 
             yield Report(date, entry_name, entry_link, company_name)
 
-    def __generate_result(self, content: str):
+    def __generate_result_for_page(self, content: str):
         """iterate trough all results and try to fetch single reports"""
         result = {}
         for element in self.__find_all_entries_on_page(content):
@@ -148,6 +148,37 @@ class Bundesanzeiger:
 
         return result
 
+    def __get_next_page_link(self, content: str):
+        soup = BeautifulSoup(content, "html.parser")
+        active_link = soup.select_one("div.page-item a.active")
+        if not active_link:
+            return None
+
+        active_index = None
+        try:
+            active_index = int(active_link.text.strip())
+        except ValueError:
+            return None
+
+        next_index = active_index + 1
+        next_link = soup.select_one(f'div.page-item a[title="Zur Seite {next_index}"]')
+        if not next_link:
+            return None
+
+        return next_link.attrs.get('href')
+
+
+    def __generate_result(self, url: str, page_limit: int):
+        results = dict()
+        pages = 0
+        while url is not None and pages < page_limit:
+            content = self.__get_response(url)
+            result_for_page = self.__generate_result_for_page(content.text)
+            results.update(**result_for_page)
+            url = self.__get_next_page_link(content.text)
+            pages += 1
+        return results
+
     def __get_response(self, url: str) -> requests.Response:
         """send a request to a URL and validate the response"""
         response = self.session.get(url)
@@ -158,10 +189,12 @@ class Bundesanzeiger:
 
         return response
 
-    def get_reports(self, company_name: str):
+    def get_reports(self, company_name: str, *, page_limit=1):
         """
         fetch all reports for this company name
         :param company_name:
+        :param page_limit: Maximum number of pages to fetch (default: 1). Normally each page has 20 reports.
+            Pass `float('inf')` to fetch all pages (this might take a while).
         :return" : "Dict of all reports
         """
         self.session.cookies["cc"] = "1628606977-805e172265bfdbde-10"
@@ -190,10 +223,8 @@ class Bundesanzeiger:
         # go to the start page
         response = self.__get_response("https://www.bundesanzeiger.de/pub/de/start?0")
         # perform the search
-        response = self.__get_response(
-            f"https://www.bundesanzeiger.de/pub/de/start?0-2.-top%7Econtent%7Epanel-left%7Ecard-form=&fulltext={company_name}&area_select=&search_button=Suchen"
-        )
-        return self.__generate_result(response.text)
+        search_url = f"https://www.bundesanzeiger.de/pub/de/start?0-2.-top%7Econtent%7Epanel-left%7Ecard-form=&fulltext={company_name}&area_select=&search_button=Suchen"
+        return self.__generate_result(search_url, page_limit)
 
 
 if __name__ == "__main__":

--- a/src/deutschland/bundesanzeiger/bundesanzeiger.py
+++ b/src/deutschland/bundesanzeiger/bundesanzeiger.py
@@ -166,8 +166,7 @@ class Bundesanzeiger:
         if not next_link:
             return None
 
-        return next_link.attrs.get('href')
-
+        return next_link.attrs.get("href")
 
     def __generate_result(self, url: str, page_limit: int):
         results = dict()

--- a/tests/bundesanzeiger/response.html
+++ b/tests/bundesanzeiger/response.html
@@ -1,0 +1,2203 @@
+<!DOCTYPE html>
+<html lang="de" data-signedin="nein" data-siteid="3">
+<head><script type="text/javascript" src="https://www.bundesanzeiger.de/pub/wicket/resource/de.banz.shared.common.panel.ModalPanel/ModalPanel-ver-5CE9B77506DEDC0F924FCB9FD201BAE9.js"></script>
+<script type="text/javascript" src="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.resource.JQueryResourceReference/jquery/jquery-3.6.0-ver-7B432A70897DCD6A8F6D26413CDF1916.js"></script>
+<script type="text/javascript" src="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.ajax.AbstractDefaultAjaxBehavior/res/js/wicket-ajax-jquery-ver-6C3579C63E0C4EBFA954D232A7F1B943.js"></script>
+<script type="text/javascript" src="https://www.bundesanzeiger.de/pub/wicket/resource/de.banz.www.input.Select/Select-ver-D41D8CD98F00B204E9800998ECF8427E.js"></script>
+
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta name="description" content="Bundesanzeiger">
+<meta name="copyright" content="Bundesanzeiger Verlag">
+<meta name="referrer" content="strict-origin">
+<meta name="revisit" content="7 days">
+<meta name="robots" content="index,follow">
+<meta name="format-detection" content="telephone=no">
+<title>
+Suchergebnis – Bundesanzeiger
+</title>
+
+<link rel="apple-touch-icon" href="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/img/favicon/apple-touch-icon-ver-AB2A8E259B7AD16EE49DAFE2BFC89F18.png" sizes="180x180" />
+<link rel="icon" href="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/img/favicon/favicon-32x32-ver-9DB9300FBD07F6EF43F6776E0E283356.png" sizes="32x32" type="image/png" />
+<link rel="icon" href="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/img/favicon/favicon-16x16-ver-86104F137C02E8AB860CE0BCB8FFF30C.png" sizes="16x16" type="image/png" />
+<link rel="mask-icon" href="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/img/favicon/safari-pinned-tab-ver-E2E9083C839C8A316D9AFC29C38C7615.svg" color="#006378" />
+<link rel="shortcut icon" href="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/img/favicon/favicon-ver-607C4A35777DEA4325C56D5986730270.ico" type="image/x-icon" />
+<link rel="stylesheet" type="text/css" href="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/css/main-ver-D42D0913DDBB932B647AF54549E3D6FD.css" media="all" />
+<noscript><link rel="stylesheet" type="text/css" href="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/css/fallback-ver-D058BBBC18DF76874662168FF9D9A0FE.css" media="all" />
+</noscript><link rel="stylesheet" type="text/css" href="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/css/plus-ver-BB87B47549F4096FFC23D6729DD7400C.css" media="all" />
+<script type="text/javascript" src="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/js/main-ver-09268C0B342BF55DED3E9EF6ABEAB37D.js"></script>
+<script type="text/javascript" src="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/js/plus-ver-5FA3E064BF47EA19077C935037B14E26.js"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+Wicket.Event.add(window, "domready", function(event) {
+initModalPanel();;
+$('#ida-0, #ida-6, #ida-7, #ida-73, #ida-74, #ida-75, #ida-93, #ida-999991, #ida-54, #ida-76, #ida-999992, #ida-29, #ida-11, #ida-16, #ida-12, #ida-13, #ida-14, #ida-15, #ida-59, #ida-87, #ida-51, #ida-62, #ida-999995, #ida-1, #ida-2, #ida-30, #ida-3, #ida-4, #ida-5, #ida-34, #ida-35, #ida-999996, #ida-18, #ida-36, #ida-90, #ida-56, #ida-57, #ida-58, #ida-72, #ida-19, #ida-20, #ida-21, #ida-61, #ida-77, #ida-39, #ida-60, #ida-79, #ida-999997, #ida-40, #ida-92, #ida-41, #ida-42, #ida-43, #ida-44, #ida-26, #ida-999998, #ida-67, #ida-69, #ida-70, #ida-71, #ida-63, #ida-91, #ida-78, #ida-66, #ida-64, #ida-89, #ida-65, #ida-68, #ida-9999922').on('change', function()
+{
+  $('#idb').trigger('click');
+}).filter(':checked');;
+Wicket.Event.add('id12_hf_1', 'click', function(event) { var b=document.getElementById('id11'); if (b!=null && b.onclick!=null && typeof(b.onclick) != 'undefined') {  var r = Wicket.bind(b.onclick, b)(); if (r != false) b.click(); } else { b.click(); };  return false;;});;
+$('#idc').on('change', function() {
+    if ($('#idc').val() != '')
+        this.form.submit();
+});
+;
+$('#id13').show();$('#id14').show();$('.concern-list0').hide();$('.subsidiary-list0').hide();;
+$('#id15').show();$('#id16').show();$('.concern-list1').hide();$('.subsidiary-list1').hide();;
+$('#id17').show();$('#id18').show();$('.concern-list2').hide();$('.subsidiary-list2').hide();;
+$('#id19').show();$('#id1a').show();$('.concern-list3').hide();$('.subsidiary-list3').hide();;
+$('#id1b').show();$('#id1c').show();$('.concern-list4').hide();$('.subsidiary-list4').hide();;
+$('#id1d').show();$('#id1e').show();$('.concern-list5').hide();$('.subsidiary-list5').hide();;
+$('#id1f').show();$('#id20').show();$('.concern-list6').hide();$('.subsidiary-list6').hide();;
+$('#id21').show();$('#id22').show();$('.concern-list7').hide();$('.subsidiary-list7').hide();;
+$('#id23').show();$('#id24').show();$('.concern-list8').hide();$('.subsidiary-list8').hide();;
+$('#id25').show();$('#id26').show();$('.concern-list9').hide();$('.subsidiary-list9').hide();;
+$('#id27').show();$('#id28').show();$('.concern-list10').hide();$('.subsidiary-list10').hide();;
+$('#id29').show();$('#id2a').show();$('.concern-list11').hide();$('.subsidiary-list11').hide();;
+$('#id2b').show();$('#id2c').show();$('.concern-list12').hide();$('.subsidiary-list12').hide();;
+$('#id2d').show();$('#id2e').show();$('.concern-list13').hide();$('.subsidiary-list13').hide();;
+$('#id2f').show();$('#id30').show();$('.concern-list14').hide();$('.subsidiary-list14').hide();;
+$('#id31').show();$('#id32').show();$('.concern-list15').hide();$('.subsidiary-list15').hide();;
+$('#id33').show();$('#id34').show();$('.concern-list16').hide();$('.subsidiary-list16').hide();;
+$('#id35').show();$('#id36').show();$('.concern-list17').hide();$('.subsidiary-list17').hide();;
+$('#id37').show();$('#id38').show();$('.concern-list18').hide();$('.subsidiary-list18').hide();;
+$('#id39').show();$('#id3a').show();$('.concern-list19').hide();$('.subsidiary-list19').hide();;
+$('#idd').on('change', function() {
+    if ($('#idd').val() != '')
+        this.form.submit();
+});
+;
+Wicket.Event.publish(Wicket.Event.Topic.AJAX_HANDLERS_BOUND);
+;});
+/*]]>*/
+</script>
+</head>
+<body data-argus="S24" class="">
+
+
+
+<noscript>
+<div class="container javascript-fallback-info">
+<div class="block margin_bottom_small">
+<div class="block-headline bg-red">
+<h3>JavaScript deaktiviert!</h3>
+</div>
+<div class="block-content">
+<p>Vergrößern Sie bitte die Fensterbreite, um die Benutzung ohne JavaScript fortzusetzen.</p>
+</div>
+</div>
+</div>
+</noscript>
+<header>
+
+<div class="cockpit">
+<div class="container">
+
+<div class="platform_block menu_button">
+<button class="platform__toggle" type="button" id="platform__content" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="platform__menu">Bundesanzeiger</button>
+<div class="dropdown-menu platform__content">
+<div class="dropdown-menu-wrapper">
+<ul class="platform__list" role="menu" id="platform__menu" aria-labelledby="platform__content" aria-label="Plattform-Auswahl">
+<li role="none">
+<a role="menuitem" href="/pub/de/start" data-argus="Shared-A45" class="active">Bundesanzeiger</a>
+</li>
+<li role="none">
+<a role="menuitem" href="/redirect/start_new/ureg/index.html?dest=ureg&amp;language=de" data-argus="Shared-A46">Unternehmensregister</a>
+</li>
+<li role="none">
+<a role="menuitem" href="/redirect/start_new?global_data.designmode=pp&amp;global_data.language=de&amp;page.navid=to_start&amp;dest=wexsservlet" data-argus="Shared-A47">Publikations-Plattform</a>
+</li>
+</ul>
+</div>
+</div>
+</div>
+
+<div class="service_block">
+<div class="service__content">
+
+<ul class="service__list sidebar" role="menu" aria-label="Service-Navigation">
+<li role="none">
+<a role="menuitem" class="btn-sidebar-home" data-toggle="tooltip" data-placement="left" href="/pub/de/start" data-argus="Shared-A13" title="Startseite"><i class="fas fa-home"></i></a>
+</li>
+<li role="none">
+<a role="menuitem" class="btn-sidebar-contact" data-toggle="tooltip" data-placement="left" href="/pub/de/kontakt" data-argus="Shared-A14" title="Kontakt"><i class="far fa-envelope"></i></a>
+</li>
+<li role="none">
+<a role="menuitem" class="btn-sidebar-faq" data-toggle="tooltip" data-placement="left" href="/pub/de/faq" data-argus="Shared-A15" title="Fragen &amp; Antworten"><i class="fas fa-question-circle"></i></a>
+</li>
+<li role="none">
+
+</li>
+</ul>
+<div class="sidebar_menu">
+<div class="sidebar__content">
+<button type="button" class="close_button close close-sidebar" aria-label="Schließen"><span aria-hidden="true">×</span></button>
+<div class="sidebar__item contact">
+<div class="header">
+<h3>
+Kontakt
+</h3>
+</div>
+<div class="container">
+<h4>Wir helfen Ihnen weiter</h4><p class="contact-info">Unsere Servicenummer: <strong>0 800 – 1 23 43 39</strong><span>Mo – Fr von 8:00 bis 18:30 Uhr, kostenlos aus dem dt. Festnetz</span></p><p class="contact-info">Aus dem Ausland:<strong>+49 221 – 9 76 68-0</strong><span>kostenpflichtig</span></p>
+<p>Bei Problemen finden Sie wertvolle Hinweise im Bereich <a href="/pub/de/faq" data-argus="Shared-A15">Fragen &amp; Antworten</a>.</p>
+</div>
+</div>
+<div class="sidebar__item faq">
+<div class="header">
+<h3>
+Fragen & Antworten
+</h3>
+</div>
+<div class="container">
+<dl class="fold"><dt>Was ist der Bundesanzeiger?</dt><dd><p>Der Bundesanzeiger ist die zentrale Plattform für amtliche Verkündungen und Bekanntmachungen sowie für rechtlich relevante Unternehmensnachrichten. Nähere Informationen zum geschichtlichen Hintergrund und zu den Aktivitäten des Bundesanzeigers finden Sie auf den Webseiten des Verlags unter <a title="Bundesanzeiger" href="https://www.bundesanzeiger-verlag.de/ueber-uns/" target="_blank">https://www.bundesanzeiger-verlag.de/ueber-uns/</a>.</p></dd><dt>Wo finde ich was?</dt><dd><p>Ein vollständiges Inhaltsverzeichnis des Bundesanzeigers wird Ihnen angezeigt, wenn Sie in der Fußzeile auf „Sitemap“ klicken. Alle Teile und Rubriken des Bundesanzeigers finden Sie unter „So geht’s – Inhalte“ oder über die Suchfunktion.</p></dd><dt>Wie kann ich suchen?</dt><dd><p>Wir bieten eine Volltextsuche und eine erweiterte Suche an. Sie können den gesamten Bundesanzeiger nach bestimmten Begriffen durchsuchen. Eine Volltextsuche über den Veröffentlichungsinhalt ist bei Jahresabschlüssen / Jahresfinanzberichten und Veröffentlichungen nach §§ 264 Abs. 3, 264b HGB nicht möglich. Bei der erweiterten Suche haben Sie die Möglichkeit, die Suche nach bestimmten Kriterien, wie zum Beispiel Veröffentlichungszeitraum oder Bereich, weiter einzuschränken.</p></dd><dt>Wie kann ich optimal drucken?</dt><dd><p>Stellen Sie im Druckmenü das Seitenlayout auf Querformat ein. Sie können Suchergebnisse oder Dokumente über Ihren Browser drucken. Es steht meist eine Druckversion zur Verfügung.</p></dd><dt>Warum kann ich kein Lesezeichen/Bookmark setzen?</dt><dd><p>Wenn Sie auf unseren Seiten suchen, bewegen Sie sich aus Sicherheitsgründen in einer so genannten „Session“. Diese ist 30 Minuten gültig, wenn Sie keine weiteren Eingaben tätigen. Dies gilt auch für ein Lesezeichen, das Sie auf eine gefundene Veröffentlichung setzen. Es wird nach 30 Minuten ungültig.</p></dd></dl>
+<p class="indent_bottom_large"><a class="btn btn-green" href="/pub/de/faq" data-argus="Shared-A81">Alle Fragen und Antworten</a></p>
+<h4>Keine Antwort gefunden?</h4><p class="contact-info">Unsere Servicenummer: <strong>0 800 – 1 23 43 39</strong> <span>Mo – Fr von 8:00 bis 18:30 Uhr, kostenlos aus dem dt. Festnetz</span></p><p class="contact-info">Aus dem Ausland: <strong>+49 221 – 9 76 68-0</strong> <span>kostenpflichtig</span></p>
+</div>
+</div>
+
+</div>
+</div>
+<div class="sidebar__shadow"></div>
+
+
+<ul class="service__list top">
+<li class="language">
+<a class="language_toggle" role="button" id="language__content" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="language__menu" data-display="static" href="">DE</a>
+<div class="dropdown-menu-wrapper">
+<ul id="language__menu" class="dropdown-menu dropdown-menu-right dropdown-menu-md-left
+language__content" aria-labelledby="language__content" role="menu" aria-label="Sprachauswahl">
+<li role="none"><a role="menuitem" href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-header~panel-lang~panel-opt~lang-1" title="Deutsche Sprache wählen" class="active">DE</a></li><li role="none"><a role="menuitem" href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-header~panel-lang~panel-opt~lang-2" title="Englische Sprache wählen" class="">EN</a></li>
+</ul>
+</div>
+</li>
+<li class="leichte_sprache"><a href="/pub/de/leichte_sprache" data-argus="Shared-A128"><span class="link-text">Leichte Sprache</span></a></li>
+
+</ul>
+
+</div>
+</div>
+</div>
+</div>
+<div class="logo_block">
+<div class="container">
+<a class="logo" href="/pub/de/start" data-argus="Shared-A4">
+<h1><img src="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/img/logo/logo_bundesanzeiger_de-ver-E551048C1482155616CAFD2D7CB04DE1.svg" alt="Bundesanzeiger"/></h1>
+</a>
+<a href="https://www.bundesanzeiger-verlag.de/" target="_blank" class="logo_banz">
+<h2><img src="https://www.bundesanzeiger.de/pub/wicket/resource/org.apache.wicket.Application/img/logo/logo_bundesanzeiger_verlag-ver-52ED89B343916436850C140F60C6DEB8.svg" alt="Bundesanzeiger Verlag"/></h2>
+</a>
+</div>
+</div>
+
+<div class="menu_block">
+<div class="container">
+<button class="menu__toggle" type="button" id="menu__content" aria-expanded="false" aria-controls="main__menu"><span></span>Menü</button>
+</div>
+<div class="menu__content" aria-labelledby="menu__content" id="main__menu" role="menu" aria-label="Hauptnavigation">
+<button type="button" class="close_button close" aria-label="Menü schließen"><span aria-hidden="true">x</span></button>
+<div class="container">
+<div class="menu__wrapper">
+<div class="row" id="accordionMenu">
+<div class="col-sm-12 col-lg-3">
+<button class="menu_headline" type="button" data-toggle="collapse" data-target="#item1" aria-expanded="false" aria-controls="item1">Suche</button>
+<ul id="item1" class="collapse menu_sublevels" data-parent="#accordionMenu" role="menu">
+<li role="none">
+<a role="menuitem" href="/pub/de/suche" data-argus="Shared-A17">Alle Bereiche</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/suche-amtlicher-teil" data-argus="Shared-A18">Amtlicher Teil</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/suche-nichtamtlicher-teil" data-argus="Shared-A19">Nichtamtlicher Teil</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/suche-gerichtlicher-teil" data-argus="Shared-A20">Gerichtlicher Teil</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/suche-gesellschaftsbekanntmachungen" data-argus="Shared-A21">Gesellschaftsbekanntmachungen</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/suche-rechnungslegung" data-argus="Shared-A22">Rechnungslegung/Finanzberichte</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/suche-kapitalmarkt" data-argus="Shared-A23">Kapitalmarkt</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/suche-verschiedene-bekanntmachungen" data-argus="Shared-A24">Verschiedene Bekanntmachungen</a>
+</li>
+</ul>
+</div>
+<div class="col-sm-12 col-lg-3">
+<button class="menu_headline" type="button" data-toggle="collapse" data-target="#item2" aria-expanded="false" aria-controls="item2">Schnellzugriff</button>
+<ul id="item2" class="collapse menu_sublevels" data-parent="#accordionMenu" role="menu">
+<li role="none">
+<strong><a role="menuitem" href="/pub/de/amtlicher-teil" data-argus="Shared-A25">Amtlicher Teil</a></strong>
+</li><li role="none">
+<strong><a role="menuitem" href="/pub/de/fondsdata" data-argus="Shared-A26">Fondsdata</a></strong>
+</li><li role="none">
+<strong><a role="menuitem" href="/pub/de/to_nlp_start" data-argus="Shared-A27">Netto-Leerverkaufspositionen</a></strong>
+</li><li role="none">
+<strong><a role="menuitem" href="/pub/de/shareholder-forum" data-argus="Shared-A44">Aktionärsforum</a></strong>
+</li><li role="none">
+<strong><a role="menuitem" href="/pub/de/restrukturierungsforum" data-argus="Shared-A130">Restrukturierungsforum</a></strong>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/aktuelle" data-argus="Shared-A28">Aktuelle Meldungen</a>
+</li>
+</ul>
+</div>
+<div class="col-sm-12 col-lg-3">
+<button class="menu_headline" type="button" data-toggle="collapse" data-target="#item3" aria-expanded="false" aria-controls="item3">So geht’s</button>
+<ul id="item3" class="collapse menu_sublevels" data-parent="#accordionMenu" role="menu">
+<li role="none">
+<a role="menuitem" href="/pub/de/howto-inhalte" data-argus="Shared-A29">Inhalte</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/howto-search" data-argus="Shared-A30">Suchen</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/howto-publish" data-argus="Shared-A31">Veröffentlichen</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/howto-hinterlegen" data-argus="Shared-A32">Jahresabschluss hinterlegen</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/howto-newsletter" data-argus="Shared-A33">Newsletter</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/howto-fondsdata" data-argus="Shared-A34">Fondsdata</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/howto-shareholder-forum" data-argus="Shared-A35">Aktionärsforum</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/howto-register" data-argus="Shared-A36">Registrieren</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/howto-info-service" data-argus="Shared-A37">Info-Dienst</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/howto-data-statistics" data-argus="Shared-A38">Daten und Statistiken</a>
+</li>
+</ul>
+</div>
+<div class="col-sm-12 col-lg-3">
+<button class="menu_headline" type="button" data-toggle="collapse" data-target="#item4" aria-expanded="false" aria-controls="item4">Service</button>
+<ul id="item4" class="collapse menu_sublevels" data-parent="#accordionMenu" role="menu">
+<li role="none">
+<a role="menuitem" href="/reg/de/info-dienst" data-argus="Shared-A39">Info-Dienst</a>
+</li><li role="none">
+<a role="menuitem" href="/reg/de/newsletter" data-argus="Shared-A16">Newsletter</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/faq" data-argus="Shared-A15">Fragen &amp; Antworten</a>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+
+<div class="user_block">
+<div class="container">
+
+<div class="dropdown login_block">
+<button class="login__toggle" type="button" id="login__content" data-toggle="dropdown" data-flip="false" aria-haspopup="true" aria-expanded="false" aria-controls="login__menu">
+<span class="btn-text">Anmelden</span><i class="fas fa-lock"></i>
+
+</button>
+<div class="dropdown-menu dropdown-menu-right login__content" aria-labelledby="login__content" id="login__menu">
+<div class="dropdown-menu-wrapper">
+<div class="login__form">
+
+
+<form id="id3b" method="post" action="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-header~panel-user~panel-login~form~panel-form"><div id="id3b_hf_0" hidden="" class="hidden-fields"></div>
+
+<div class="form-group">
+<input type="text" class="form-control" value="" name="email" id="ide" data-argus="Shared-L10" placeholder="E-Mail-Adresse oder Benutzername"/>
+</div>
+<div class="form-group">
+<input type="password" class="form-control" value="" name="password" id="idf" data-argus="Shared-L11" placeholder="Passwort"/>
+</div>
+<input type="submit" class="btn btn-green btn-extend" name="login-button" id="id3c" value="Anmelden" data-argus="Shared-B8"/>
+</form>
+
+
+</div>
+<div class="login__links">
+<ul role="menu">
+<li role="none">
+<strong><a role="menuitem" href="/reg/de/account/registrierung-start" data-argus="Shared-A41">Registrieren</a></strong>
+</li><li role="none">
+<a role="menuitem" href="/reg/de/change_password" data-argus="Shared-A72">Passwort vergessen?</a>
+</li><li role="none">
+<a role="menuitem" href="/reg/de/resend_confirm_mail" data-argus="Shared-A71">Registrierungs-E-Mail erneut zusenden</a>
+</li><li role="none">
+<a role="menuitem" href="https://www.bundesanzeiger.de/pub/de/help?key=Shared-Q1" data-argus="Shared-A73">Hilfe</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/sicherheitshinweise" data-argus="Shared-A11">Sicherheitshinweise</a>
+</li><li role="none">
+
+</li><li role="none">
+
+</li><li role="none">
+
+</li><li role="none">
+
+</li><li role="none">
+
+</li><li role="none">
+
+</li><li role="none">
+
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+<div class="menu__shadow"></div>
+
+
+</header>
+<div id="content" class="content">
+
+<section class="breadcrumb">
+
+
+<div class="container">
+<div class="row">
+<ul class="breadcrumb-nav" role="menu" aria-label="Sie befinden sich hier:">
+<li role="none">
+<a role="menuitem" href="https://www.bundesanzeiger.de/pub/de/start" data-argus="S1">Startseite</a>
+</li><li role="none" class="active">
+<a role="menuitem" data-argus="S24" disabled="disabled" class="active" href="#">Suchergebnis</a>
+</li>
+</ul>
+</div>
+</div>
+
+
+</section>
+
+
+<section class="indent_top_small indent_bottom_small">
+<div class="container">
+<div class="row">
+<div class="col-sm-12">
+
+<div class="content-container margin_bottom_large">
+
+<h1>Suchergebnis</h1>
+
+
+
+
+<div id="searchoptions" class="accordion" data-toggle="false">
+<div class="card">
+<div id="searchoptions-headings" class="card-header header-accordion">
+
+<h4><button data-target="#searchoptions-collapse" aria-controls="searchoptions-collapse" name="show-form-button" id="id3d" data-argus="B21" class="btn btn-link" type="button" data-toggle="collapse" aria-expanded="false">Suchoptionen</button>
+</h4>
+</div>
+<div class="collapse " id="searchoptions-collapse">
+<div class="card-body">
+
+<div class="search_container all">
+<form class="search-form" id="id12" method="post" action="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-detail~form-search~form"><div id="id12_hf_0" hidden="" class="hidden-fields"></div><div hidden="" class="hidden-fields"><input type="text" tabindex="-1" autocomplete="off"/><input id="id12_hf_1" type="submit" tabindex="-1" name="search-button" /></div>
+<div class="alert alert-primary mb-20">
+
+<p>Eine Volltextsuche über den Veröffentlichungsinhalt ist bei Rechnungslegungsunterlagen und Unternehmensberichten – d. h. bei Veröffentlichungen im Bereich „Rechnungslegung/Finanzberichte“ – nicht möglich.</p><p>Hinterlegte Jahresabschlussunterlagen stehen im <a href="https://www.unternehmensregister.de">Unternehmensregister</a> zur Beauskunftung zur Verfügung.</p>
+</div>
+
+<div class="search-row">
+  <div class="col"><input value="Deutsches Zentrum für Luft- und Raumfahrt" name="fulltext" id="id10" data-argus="L43" type="text" placeholder="Suchbegriff eingeben" class="form-control"/>
+  </div>
+</div>
+<div id="part_search_reset" class="noscript-only">
+<h2>Alle Bereiche</h2>
+<input type="submit" class="btn btn-green btn-cat-select noscript-only" name="reset-button" id="id3e" value="Auswahl zurücksetzen" data-argus="B35">
+</div>
+<div class="search-row">
+<div class="col">
+<div id="part_search" class="accordion" data-toggle="false">
+<div class="card">
+<div id="part_search-heading" class="card-header header-accordion">
+
+<h4><button data-target="#part_search-collapse" aria-controls="part_search-collapse" name="accordion-show-area-button" id="id3f" data-argus="Shared-A17" class="btn btn-link" type="button" data-toggle="collapse" aria-expanded="false">Alle Bereiche</button>
+</h4>
+</div>
+<div class="collapse" id="part_search-collapse">
+<div class="card-body">
+<div class="row">
+<div class="col">
+
+
+<div id="part_cat_all">
+<div class="custom-control custom-radio">
+<input type="radio" id="ida-0" name="panelCategories:groupCategories" value="0" checked="checked" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-0">Alle Bereiche</label>
+</div>
+</div>
+<div id="part_cat" class="accordion" data-toggle="false">
+<div class="card">
+<div class="card-header">
+
+<h4><button data-target="#area1" aria-controls="area1" name="panelCategories:groupCategories:accordion-show-area1" id="id40" data-argus="Shared-A18" class="btn btn-link" type="button" data-toggle="collapse" aria-expanded="false">Amtlicher Teil</button>
+</h4>
+</div>
+<div id="area1" class="collapse" data-parent="#part_cat">
+<div class="card-body">
+<div class="row">
+<div class="col">
+<div class="custom-control custom-radio">
+<input type="radio" id="ida-6" name="panelCategories:groupCategories" value="6" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-6">Verkündungen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-7" name="panelCategories:groupCategories" value="7" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-7">Bekanntmachungen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-73" name="panelCategories:groupCategories" value="73" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-73">Ausschreibungen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-74" name="panelCategories:groupCategories" value="74" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-74">Sonstiges</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-75" name="panelCategories:groupCategories" value="75" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-75">Hinweise</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-93" name="panelCategories:groupCategories" value="93" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-93">Ersatzverkündungen und -bekanntmachungen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-999991" name="panelCategories:groupCategories" value="999991" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-999991">Alles</label>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="card">
+<div class="card-header">
+
+<h4><button data-target="#area2" aria-controls="area2" name="panelCategories:groupCategories:accordion-show-area2" id="id41" data-argus="Shared-A19" class="btn btn-link" type="button" data-toggle="collapse" aria-expanded="false">Nichtamtlicher Teil</button>
+</h4>
+</div>
+<div id="area2" class="collapse" data-parent="#part_cat">
+<div class="card-body">
+<div class="row">
+<div class="col">
+<div class="custom-control custom-radio">
+<input type="radio" id="ida-54" name="panelCategories:groupCategories" value="54" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-54">Institutionelle Veröffentlichungen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-76" name="panelCategories:groupCategories" value="76" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-76">Sonstiges</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-999992" name="panelCategories:groupCategories" value="999992" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-999992">Alles</label>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="card">
+<div class="card-header">
+
+<h4><button data-target="#area5" aria-controls="area5" name="panelCategories:groupCategories:accordion-show-area5" id="id42" data-argus="Shared-A20" class="btn btn-link" type="button" data-toggle="collapse" aria-expanded="false">Gerichtlicher Teil</button>
+</h4>
+</div>
+<div id="area5" class="collapse" data-parent="#part_cat">
+<div class="card-body">
+<div class="row">
+<div class="col">
+<div class="custom-control custom-radio">
+<input type="radio" id="ida-29" name="panelCategories:groupCategories" value="29" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-29">Klageregister (nach dem Kapitalanleger-Musterverfahrensgesetz)</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-11" name="panelCategories:groupCategories" value="11" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-11">Öffentliche Zustellungen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-16" name="panelCategories:groupCategories" value="16" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-16">Strafsachen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-12" name="panelCategories:groupCategories" value="12" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-12">Aufgebote von Personen in Grundstücks-, Nachlasssachen usw.</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-13" name="panelCategories:groupCategories" value="13" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-13">Aufgebote von Urkunden</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-14" name="panelCategories:groupCategories" value="14" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-14">Ausschlussurteile, Kraftloserklärungen und sonstige Beschlüsse</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-15" name="panelCategories:groupCategories" value="15" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-15">Beiladungen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-59" name="panelCategories:groupCategories" value="59" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-59">Konkurse, Gesamtvollstreckungs- und Insolvenzverfahren</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-87" name="panelCategories:groupCategories" value="87" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-87">Restrukturierungsforum</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-51" name="panelCategories:groupCategories" value="51" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-51">Register anonymer und pseudonymer Werke</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-62" name="panelCategories:groupCategories" value="62" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-62">Verschiedenes</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-999995" name="panelCategories:groupCategories" value="999995" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-999995">Alles</label>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="card">
+<div class="card-header">
+
+<h4><button data-target="#area6" aria-controls="area6" name="panelCategories:groupCategories:accordion-show-area6" id="id43" data-argus="Shared-A21" class="btn btn-link" type="button" data-toggle="collapse" aria-expanded="false">Gesellschaftsbekanntmachungen</button>
+</h4>
+</div>
+<div id="area6" class="collapse" data-parent="#part_cat">
+<div class="card-body">
+<div class="row">
+<div class="col">
+<div class="custom-control custom-radio">
+<input type="radio" id="ida-1" name="panelCategories:groupCategories" value="1" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-1">Aktiengesellschaften</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-2" name="panelCategories:groupCategories" value="2" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-2">Kommanditgesellschaften auf Aktien</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-30" name="panelCategories:groupCategories" value="30" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-30">Aktionärsforum</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-3" name="panelCategories:groupCategories" value="3" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-3">Gesellschaften mbH</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-4" name="panelCategories:groupCategories" value="4" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-4">Genossenschaften</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-5" name="panelCategories:groupCategories" value="5" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-5">Offene Handels- und Kommanditgesellschaften</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-34" name="panelCategories:groupCategories" value="34" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-34">Versicherungsvereine auf Gegenseitigkeit</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-35" name="panelCategories:groupCategories" value="35" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-35">Ausländische Gesellschaften</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-999996" name="panelCategories:groupCategories" value="999996" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-999996">Alles</label>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="card">
+<div class="card-header">
+
+<h4><button data-target="#area22" aria-controls="area22" name="panelCategories:groupCategories:accordion-show-area22" id="id44" data-argus="Shared-A22" class="btn btn-link" type="button" data-toggle="collapse" aria-expanded="false">Rechnungslegung/Finanzberichte</button>
+</h4>
+</div>
+<div id="area22" class="collapse" data-parent="#part_cat">
+<div class="card-body">
+<div class="row">
+<div class="col">
+<div class="custom-control custom-radio">
+<input type="radio" id="ida-67" name="panelCategories:groupCategories" value="67" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-67">Jahresabschlüsse</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-69" name="panelCategories:groupCategories" value="69" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-69">Halbjahresfinanzbericht nach WpHG</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-70" name="panelCategories:groupCategories" value="70" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-70">Quartalsfinanzbericht nach WpHG</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-71" name="panelCategories:groupCategories" value="71" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-71">Zwischenmitteilung nach WpHG</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-63" name="panelCategories:groupCategories" value="63" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-63">§§ 264 Abs. 3, 264b HGB (Befreiung)</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-91" name="panelCategories:groupCategories" value="91" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-91">Gesonderter nichtfinanzieller Bericht außerhalb des Lageberichts</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-78" name="panelCategories:groupCategories" value="78" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-78">Rechnungslegungsunterlagen von Krankenkassen und Kassenärztlichen Vereinigungen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-66" name="panelCategories:groupCategories" value="66" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-66">Hinweis nach WpHG</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-64" name="panelCategories:groupCategories" value="64" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-64">Fehlerbekanntmachungen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-89" name="panelCategories:groupCategories" value="89" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-89">Zahlungsberichte</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-65" name="panelCategories:groupCategories" value="65" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-65">Hinterlegungsbekanntmachungen (Geschäftsjahre beginnend vor 1.1.2006)</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-68" name="panelCategories:groupCategories" value="68" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-68">Verschiedenes</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-9999922" name="panelCategories:groupCategories" value="9999922" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-9999922">Alles</label>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="card">
+<div class="card-header">
+
+<h4><button data-target="#area7" aria-controls="area7" name="panelCategories:groupCategories:accordion-show-area7" id="id45" data-argus="Shared-A23" class="btn btn-link" type="button" data-toggle="collapse" aria-expanded="false">Kapitalmarkt</button>
+</h4>
+</div>
+<div id="area7" class="collapse" data-parent="#part_cat">
+<div class="card-body">
+<div class="row">
+<div class="col">
+<div class="custom-control custom-radio">
+<input type="radio" id="ida-18" name="panelCategories:groupCategories" value="18" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-18">Investmentvermögen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-36" name="panelCategories:groupCategories" value="36" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-36">Besteuerungsgrundlagen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-90" name="panelCategories:groupCategories" value="90" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-90">Herkunftsstaat</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-56" name="panelCategories:groupCategories" value="56" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-56">Insiderinformationen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-57" name="panelCategories:groupCategories" value="57" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-57">Eigengeschäfte von Führungskräften</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-58" name="panelCategories:groupCategories" value="58" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-58">Stimmrechtsmitteilungen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-72" name="panelCategories:groupCategories" value="72" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-72">Leerverkäufe</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-19" name="panelCategories:groupCategories" value="19" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-19">Fondspreise</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-20" name="panelCategories:groupCategories" value="20" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-20">Inventarwerte</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-21" name="panelCategories:groupCategories" value="21" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-21">Aktienkurse</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-61" name="panelCategories:groupCategories" value="61" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-61">Wertpapiere</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-77" name="panelCategories:groupCategories" value="77" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-77">Vermögensanlagen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-39" name="panelCategories:groupCategories" value="39" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-39">Wertpapiererwerb und Übernahme</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-60" name="panelCategories:groupCategories" value="60" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-60">Hinweise nach Solvabilitätsverordnung</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-79" name="panelCategories:groupCategories" value="79" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-79">Offenlegungen nach VO (EU) 575/2013, VO (EU) 2019/2033</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-999997" name="panelCategories:groupCategories" value="999997" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-999997">Alles</label>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="card">
+<div class="card-header">
+
+<h4><button data-target="#area8" aria-controls="area8" name="panelCategories:groupCategories:accordion-show-area8" id="id46" data-argus="Shared-A24" class="btn btn-link" type="button" data-toggle="collapse" aria-expanded="false">Verschiedene Bekanntmachungen</button>
+</h4>
+</div>
+<div id="area8" class="collapse" data-parent="#part_cat">
+<div class="card-body">
+<div class="row">
+<div class="col">
+<div class="custom-control custom-radio">
+<input type="radio" id="ida-40" name="panelCategories:groupCategories" value="40" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-40">Ausschreibungen</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-92" name="panelCategories:groupCategories" value="92" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-92">Berichte nach DSA, DDG, NetzDG</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-41" name="panelCategories:groupCategories" value="41" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-41">Berufsgenossenschaften</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-42" name="panelCategories:groupCategories" value="42" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-42">Krankenkassen (Gesetzliche-, Betriebs- und Innungskassen)</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-43" name="panelCategories:groupCategories" value="43" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-43">Vereine und Verbände</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-44" name="panelCategories:groupCategories" value="44" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-44">Verwertungsgesellschaften</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-26" name="panelCategories:groupCategories" value="26" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-26">Verschiedenes</label>
+</div><div class="custom-control custom-radio">
+<input type="radio" id="ida-999998" name="panelCategories:groupCategories" value="999998" class="radio custom-control-input"/>
+<label class="custom-control-label" for="ida-999998">Alles</label>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<input type="submit" class="btn btn-green btn-cat-select noscript-only" name="panelCategories:groupCategories:apply-button" id="id47" value="Auswahl anwenden" data-argus="B36">
+
+
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="submit-wrapper noscript-only">
+<input type="submit" class="btn btn-green" name="other-options-button" id="idb" value="Weiter eingrenzen" data-argus="B24"/>
+</div>
+</div>
+</div>
+<div class="search-row">
+
+</div>
+<div class="search-row datepicker">
+<div class="row">
+<div class="col-lg-4">
+<p class="label">Veröffentlichungszeitraum</p>
+</div>
+<div class="col-md-6 col-lg-4">
+
+<div class="form-group">
+  <div id="date-from" class="input-group date">
+    <div class="input-group-prepend">
+      <span class="input-group-text">von</span>
+    </div><input type="text" value="" name="start_date" id="id48" data-argus="L44" placeholder="tt.mm.jjjj" class="form-control"/>
+    <span class="input-group-addon"><span class="fa fa-calendar-alt"></span></span>
+  </div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+
+<div class="form-group">
+  <div id="date-to" class="input-group date">
+    <div class="input-group-prepend">
+      <span class="input-group-text">bis</span>
+    </div><input type="text" value="" name="end_date" id="id49" data-argus="L45" placeholder="tt.mm.jjjj" class="form-control"/>
+    <span class="input-group-addon"><span class="fa fa-calendar-alt"></span></span>
+  </div>
+</div>
+</div>
+</div>
+</div>
+<div class="search-row submit">
+<input type="submit" class="btn btn-green" name="search-button" id="id11" value="Suchen" data-argus="B20"/>
+</div>
+</form>
+</div>
+
+</div>
+</div>
+</div>
+</div>
+
+<div id="piwik_info" class="result_info" data-searchterm="Deutsches Zentrum für Luft- und Raumfahrt" data-count="365">
+<h2>Ergebnisse für Suchbegriff <strong>„Deutsches Zentrum für Luft- und Raumfahrt“</strong></h2>
+</div>
+
+
+<div class="result_filter">
+<p class="label">Suchbereich:</p>
+<div class="dropdown">
+<button id="dropdownMenuButton" name="result-filter-panel:dropdown-show-filter-button" data-argus="B26" class="btn dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true" data-display="static">Alle Bereiche<span class="counter"> (365 Treffer)</span></button>
+<div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+<ul class="filter-list">
+<li  class="link-filter-n0 "><a class=" active">Alle Bereiche (365)</a></li><li id="1" class="link-filter-n1 "><a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-result~filter~panel-filter~list-2" class="">Amtlicher Teil (316)</a></li><li id="7" class="link-filter-n1 "><a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-result~filter~panel-filter~list-3" class="">Kapitalmarkt (4)</a></li><li id="8" class="link-filter-n1 "><a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-result~filter~panel-filter~list-4" class="">Verschiedene Bekanntmachungen (45)</a></li>
+</ul>
+</div>
+</div>
+</div>
+<div class="result_filter_btn">
+<ul class="filter-btn-list">
+
+</ul>
+</div>
+
+
+
+<div class="result_pager">
+<div class="page_count">
+<span>19</span>&nbsp;Seiten
+</div>
+<div class="pager_wrapper">
+<nav aria-label="Pagination">
+<div class="pagination">
+<div class="left">
+<div class="first">
+<a class="page-nav" title="Zur ersten Seite"><i class="fas fa-step-backward"></i></a>
+</div>
+<div class="prev">
+<a class="page-nav" title="Zur vorherigen Seite"><i class="fas fa-angle-left"></i></a>
+</div>
+</div>
+<div class="middle">
+
+<div class="page-item first" ><a class=" active" title="Zur Seite 1">
+1
+</a></div>
+
+<div class="page-item first" ><a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-top~nav-pager-navigation-1-pagination~link" class="" title="Zur Seite 2">
+2
+</a></div>
+
+<div class="page-item first" ><a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-top~nav-pager-navigation-2-pagination~link" class="" title="Zur Seite 3">
+3
+</a></div>
+
+<div class="page-item first" ><a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-top~nav-pager-navigation-3-pagination~link" class="" title="Zur Seite 4">
+4
+</a></div>
+
+<div class="page-item first" ><a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-top~nav-pager-navigation-4-pagination~link" class="" title="Zur Seite 5">
+5
+</a></div>
+
+</div>
+<div class="right">
+<div class="next">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-top~nav-pager-next" class="page-nav" title="Zur nächsten Seite"><i class="fas fa-angle-right"></i></a>
+</div>
+<div class="last">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-top~nav-pager-last" class="page-nav" title="Zur letzten Seite"><i class="fas fa-step-forward"></i></a>
+</div>
+</div>
+</div>
+</nav>
+</div>
+<div class="pager_items">
+<form id="id4b" method="post" action="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-top~nav-form"><div id="id4b_hf_0" hidden="" class="hidden-fields"></div>
+<label id="id4c" for="idc">Ergebnisse pro Seite:</label>
+<div class="form-group">
+
+<div class="select-wrapper"><select name="hitsperpage-select" id="idc" data-argus="L16" data-live-search="false" data-live-search-style="contains" data-select-on-tab="true" class="select">
+<option value="argus-HitsPerPage10">10</option>
+<option selected="selected" value="argus-HitsPerPage20">20</option>
+<option value="argus-HitsPerPage30">30</option>
+<option value="argus-HitsPerPage50">50</option>
+<option value="argus-HitsPerPage100">100</option>
+</select>
+</div>
+<button type="submit" class="btn btn-update noscript-only" title="Aktualisieren">
+<i class="fas fa-sync-alt"></i><span class="sr-only">Aktualisieren</span>
+</button>
+</div>
+</form>
+</div>
+</div>
+
+
+<div class="container result_container global-search">
+<div class="row sticky-top result_header">
+<div class="col-md-3">Name&nbsp;<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-sort~name~desc" class="btn btn-sort " title="Absteigend sortieren"><i class="fas fa-angle-down"></i></a>&nbsp;<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-sort~name~asc" class="btn btn-sort " title="Aufsteigend sortieren"><i class="fas fa-angle-up"></i></a></div>
+<div class="col-md-2">Bereich</div>
+<div class="col-md-5">Information&nbsp;<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-sort~info~desc" class="btn btn-sort " title="Absteigend sortieren"><i class="fas fa-angle-down"></i></a>&nbsp;<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-sort~info~asc" class="btn btn-sort " title="Aufsteigend sortieren"><i class="fas fa-angle-up"></i></a></div>
+<div class="col-md-2">V.-Datum&nbsp;<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-sort~date~desc" class="btn btn-sort " title="Absteigend sortieren"><i class="fas fa-angle-down"></i></a>&nbsp;<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-sort~date~asc" class="btn btn-sort " title="Aufsteigend sortieren"><i class="fas fa-angle-up"></i></a></div>
+</div>
+
+
+<div class="row back">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Bonn
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-0-search~table~row~panel-publication~link">Bericht über die Bezüge des Vorstands im Geschäftsjahr 2022</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+13.09.2023
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row">
+<div class="col-md-3">
+<div class="first">
+Raumfahrtagentur im Deutschen Zentrum für Luft- und Raumfahrt e.V. (DLR)
+
+<br/>Königswinterer Straße 522-524 / 53227 Bonn
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-1-search~table~row~panel-publication~link">Förderung von Vorhaben im Bereich „Entwicklung und Implementierungsvorbereitung von Copernicus Diensten für den öffentlichen Bedarf in Deutschland“</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+04.09.2023
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row back">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Bonn
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-2-search~table~row~panel-publication~link">Bericht über die Bezüge des Vorstands im Geschäftsjahr 2021</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+11.11.2022
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Bonn
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-3-search~table~row~panel-publication~link">Bericht über die Bezüge des Vorstands im Geschäftsjahr 2020</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+28.01.2022
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row back">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Köln
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-4-search~table~row~panel-publication~link">Förderung von Projekten im Bereich Erdbeobachtung zum Thema „Entwicklung innovativer Methoden und Dienste zur anwendungsorientierten Nutzungsvorbereitung der EnMAP-Mission“</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+14.07.2021
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Köln
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-5-search~table~row~panel-publication~link">Förderung von Vorhaben im Bereich „Entwicklung und Implementierungsvorbereitung von Copernicus Diensten für den öffentlichen Bedarf in Deutschland“</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+21.05.2021
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row back">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Köln
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-6-search~table~row~panel-publication~link">Änderung der Bekanntmachung: Fristverlängerung zur Vorlage von Projektskizzen</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<br/><b>Berichtigung der Veröffentlichung vom 24.12.2020</b>
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+19.02.2021
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Köln
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-7-search~table~row~panel-publication~link">Förderung von Vorhaben im Bereich „Entwicklung und Implementierungsvorbereitung von Copernicus Diensten für den öffentlichen Bedarf zum Thema Klimaanpassungsstrategien für kommunale Anwendungen in Deutschland“</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<br/><b>Berichtigt am 19.02.2021</b>
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+24.12.2020
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row back">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Bonn
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-8-search~table~row~panel-publication~link">Bericht über die Bezüge des Vorstands im Geschäftsjahr 2019</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+12.10.2020
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Köln
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-9-search~table~row~panel-publication~link">ÄNDERUNG der Bekanntmachung &quot;Förderung von Vorhaben im Bereich Erdbeobachtung&quot; (veröffentlicht am 22.05.2020)</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+01.07.2020
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row back">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Köln
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-10-search~table~row~panel-publication~link">Förderung von Vorhaben im Bereich Erdbeobachtung zum Thema: Entwicklung und Nutzung von Methoden der Künstlichen Intelligenz für den anwendungsorientierten Einsatz in der Satellitenerdbeobachtung</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+22.05.2020
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Köln
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-11-search~table~row~panel-publication~link">Förderung von Vorhaben zur Weiterentwicklung und Optimierung von additiven Metalldruck- und Bioprintingverfahren für Anwendungen unter reduzierten Schwerkraftbedingungen</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+03.03.2020
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row back">
+<div class="col-md-3">
+<div class="first">
+Raumfahrtmanagement des Deutschen Zentrums für Luft- und Raumfahrt e. V.
+
+<br/>Königswinterer Straße 522-52453227 Bonn
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-12-search~table~row~panel-publication~link">Umsetzung von Maßnahmen im Rahmen des nationalen Programms zur Förderung von Galileo PRS</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+08.01.2020
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Köln
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-13-search~table~row~panel-publication~link">Förderung von Vorhaben im Bereich „Entwicklung und Implementierungsvorbereitung von Copernicus Diensten für den öffentlichen Bedarf in Deutschland“</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+19.12.2019
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row back">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Bonn
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-14-search~table~row~panel-publication~link">Bericht über die Bezüge des Vorstands im Geschäftsjahr 2018</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+30.09.2019
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Bonn
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-15-search~table~row~panel-publication~link">Förderung von „Vorhaben im Bereich Automatisierungstechnologien &amp; Robotik - Förderschwerpunkt 1 „Providing Services“</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+07.06.2019
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row back">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Bonn
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-16-search~table~row~panel-publication~link">Förderung von „Vorhaben im Bereich Automatisierungstechnologien &amp; Robotik - Förderschwerpunkt 2 „Receiving Services“</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+07.06.2019
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Bonn
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-17-search~table~row~panel-publication~link">Bericht über die Bezüge des Vorstands im Geschäftsjahr 2017</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+24.12.2018
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row back">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt (DLR) e. V.
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-18-search~table~row~panel-publication~link">Förderung von Vorhaben im Bereich Erdbeobachtung zum Thema  „Entwicklung innovativer Methoden zur Erstellung erdbeobachtungsbasierter Informationsprodukte“</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+02.10.2018
+</div>
+</div>
+</div>
+
+
+
+
+
+
+
+<div class="row">
+<div class="col-md-3">
+<div class="first">
+Deutsches Zentrum für Luft- und Raumfahrt e. V.
+
+<br/>Köln
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="part">
+Verschiedene Bekanntmachungen
+</div>
+</div>
+<div class="col-md-5">
+<div class="info">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-search~table~panel-rows-19-search~table~row~panel-publication~link">Förderung von Innovations- und Transfervorhaben der Raumfahrt</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<div class="col-md-2">
+<div class="date">
+06.09.2018
+</div>
+</div>
+</div>
+
+
+
+
+
+
+</div>
+
+
+<div class="result_pager bottom">
+<div class="page_count">
+<span>19</span>&nbsp;Seiten
+</div>
+<div class="pager_wrapper">
+<nav aria-label="Pagination">
+<div class="pagination">
+<div class="left">
+<div class="first">
+<a class="page-nav" title="Zur ersten Seite"><i class="fas fa-step-backward"></i></a>
+</div>
+<div class="prev">
+<a class="page-nav" title="Zur vorherigen Seite"><i class="fas fa-angle-left"></i></a>
+</div>
+</div>
+<div class="middle">
+
+<div class="page-item first" ><a class=" active" title="Zur Seite 1">
+1
+</a></div>
+
+<div class="page-item first" ><a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-bottom~nav-pager-navigation-1-pagination~link" class="" title="Zur Seite 2">
+2
+</a></div>
+
+<div class="page-item first" ><a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-bottom~nav-pager-navigation-2-pagination~link" class="" title="Zur Seite 3">
+3
+</a></div>
+
+<div class="page-item first" ><a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-bottom~nav-pager-navigation-3-pagination~link" class="" title="Zur Seite 4">
+4
+</a></div>
+
+<div class="page-item first" ><a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-bottom~nav-pager-navigation-4-pagination~link" class="" title="Zur Seite 5">
+5
+</a></div>
+
+</div>
+<div class="right">
+<div class="next">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-bottom~nav-pager-next" class="page-nav" title="Zur nächsten Seite"><i class="fas fa-angle-right"></i></a>
+</div>
+<div class="last">
+<a href="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-bottom~nav-pager-last" class="page-nav" title="Zur letzten Seite"><i class="fas fa-step-forward"></i></a>
+</div>
+</div>
+</div>
+</nav>
+</div>
+<div class="pager_items">
+<form id="idb3" method="post" action="https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-bottom~nav-form"><div id="idb3_hf_0" hidden="" class="hidden-fields"></div>
+<label id="idb4" for="idd">Ergebnisse pro Seite:</label>
+<div class="form-group">
+
+<div class="select-wrapper"><select name="hitsperpage-select" id="idd" data-argus="L16" data-live-search="false" data-live-search-style="contains" data-select-on-tab="true" class="select">
+<option value="argus-HitsPerPage10">10</option>
+<option selected="selected" value="argus-HitsPerPage20">20</option>
+<option value="argus-HitsPerPage30">30</option>
+<option value="argus-HitsPerPage50">50</option>
+<option value="argus-HitsPerPage100">100</option>
+</select>
+</div>
+<button type="submit" class="btn btn-update noscript-only" title="Aktualisieren">
+<i class="fas fa-sync-alt"></i><span class="sr-only">Aktualisieren</span>
+</button>
+</div>
+</form>
+</div>
+</div>
+
+
+
+
+
+</div>
+
+
+</div>
+
+</div>
+</div>
+</section>
+
+<div class="modal fade" id="info" tabindex="-1" role="dialog">
+<div class="modal-dialog" role="document">
+<div class="modal-content">
+<div class="modal-header">
+<h5 class="modal-title"></h5>
+<button type="button" class="close" data-dismiss="modal" aria-label="Schließen"><span aria-hidden="true">&times;</span></button>
+</div>
+<div class="modal-body">
+</div>
+</div>
+</div>
+</div>
+
+</div>
+<footer>
+<div class="container">
+<div class="footer-content">
+<ul class="footer-nav" role="menu" aria-label="Fusszeile-Navigation">
+<li role="none">
+<a role="menuitem" href="/pub/de/impressum" data-argus="Shared-A8" id="cc_imprint">Impressum</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/datenschutzerklaerung" data-argus="Shared-A9" id="cc_privacy">Datenschutzerklärung</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/rechtliches" data-argus="Shared-A10">Rechtliches / <abbr title="Allgemeine Geschäftsbedingungen">AGB</abbr></a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/sicherheitshinweise" data-argus="Shared-A11">Sicherheitshinweise</a>
+</li><li role="none">
+<a role="menuitem" href="/pub/de/sitemap" data-argus="Shared-A12">Sitemap</a>
+</li>
+<li role="none" class="logo_banz_footer">
+<a role="menuitem" href="https://www.bundesanzeiger-verlag.de" target="_blank">
+Bundesanzeiger Verlag
+</a>
+</li>
+</ul>
+<a href="#" title="nach oben" class="scroll-to-top" aria-label="nach oben" data-toggle="tooltip" data-placement="top"><span class="sr-only">nach oben</span></a>
+</div>
+</div>
+</footer>
+
+
+<div id="cc" style="display:none;">
+<div id="cc_banner">
+<h4>Cookie-Einstellungen</h4><p>Wir setzen Statistik-Cookies ein, um unsere Webseiten optimal für Sie zu gestalten und unsere Plattformen für Sie zu verbessern. Sie können auswählen, ob Sie neben dem Einsatz technisch notwendiger Cookies der Verarbeitung aus statistischen Gründen zustimmen oder ob Sie <b>nur technisch notwendige Cookies</b> zulassen wollen. Weitere Informationen sowie die Möglichkeit, Ihre Auswahl jederzeit zu ändern und erteilte Einwilligung zu widerrufen, finden Sie in unserer <a class="cc_privacy">Datenschutzerklärung</a>.</p><p>Mit einem Klick auf <b>Allen zustimmen</b> willigen Sie in die Verarbeitung zu statistischen Zwecken ein.</p><div class="cc_commands"><button>Nur technisch notwendige Cookies akzeptieren</button><button id="cc_all">Allen zustimmen</button></div><div class="float-left">Cookie-ID: <span class="cc_id"></span></div><div class="float-right"><a class="cc_imprint">Impressum</a></div>
+</div>
+</div>
+</body>
+</html>

--- a/tests/bundesanzeiger/test_parsing.py
+++ b/tests/bundesanzeiger/test_parsing.py
@@ -1,0 +1,9 @@
+from deutschland.bundesanzeiger import Bundesanzeiger
+
+
+def test_get_next_page_link():
+    with open('response.html') as file:
+        ba = Bundesanzeiger()
+        html = file.read()
+        link = ba._Bundesanzeiger__get_next_page_link(html)
+        assert link == 'https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-top~nav-pager-navigation-1-pagination~link'

--- a/tests/bundesanzeiger/test_parsing.py
+++ b/tests/bundesanzeiger/test_parsing.py
@@ -1,9 +1,12 @@
+import os
 from deutschland.bundesanzeiger import Bundesanzeiger
 
 
 def test_get_next_page_link():
-    with open('response.html') as file:
-        ba = Bundesanzeiger()
+    html_file = os.path.join(os.path.dirname(__file__), "response.html")
+    with open(html_file) as file:
         html = file.read()
-        link = ba._Bundesanzeiger__get_next_page_link(html)
-        assert link == 'https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-top~nav-pager-navigation-1-pagination~link'
+    ba = Bundesanzeiger()
+    link = ba._Bundesanzeiger__get_next_page_link(html)
+    expected = "https://www.bundesanzeiger.de/pub/de/suchen2?4-1.-top~nav-pager-navigation-1-pagination~link"
+    assert link == expected

--- a/tests/bundesanzeiger/test_results.py
+++ b/tests/bundesanzeiger/test_results.py
@@ -7,8 +7,8 @@ def test_results_not_empty():
     assert len(reports) > 0
 
 
-def test_multiple_entries():
+def test_multiple_pages():
     ba = Bundesanzeiger()
-    reports = ba.get_reports("DE000A0TGJ55")
+    reports = ba.get_reports("DE000A0TGJ55", page_limit=2)
 
-    assert len(reports) > 1
+    assert len(reports) == 40


### PR DESCRIPTION
The current Bundesanzeiger implementation only fetches one page of results with up to 20 reports, but sometimes it might be interesting to get older reports as well.

This adds a named parameter `page_limit` to `Bundesanzeiger.get_reports`. The default value is 1, which preserves the current behavior of fetching only one page. If a higher value is set, the client will search the returned HTML for a "next page" link, and keep generating reports until page_limits pages have been parsed or there is no "next page" link anymore. `float('inf')` can be passed to fetch all available pages.

This commit adds a unit test for the method to find the "next page" link and another to test that it actually generates more than 20 reports.

This also encodes the company name in the URL so that search terms like `"Saxony Minerals & Exploration - SME AG"` work correctly.