### PR TITLE
Update workflows and removed python 3.8 due to lacking support

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -18,7 +18,7 @@ jobs:
           sphinx-apidoc -o source/ ../src/deutschland
           make html
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4 # v3 is deprecated
         with:
           name: "documentation"
           path: ${{ github.workspace }}/sphinx-docs/_build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7.13]
+        python-version: ['3.8', '3.12'] # covers rane of supported python versions
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.12'] # covers rane of supported python versions
+        python-version: ['3.9', '3.10', '3.11', '3.12'] # covers rane of supported python versions
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "windows-latest","ubuntu-latest"]
-        python-version: ["3.9.13","3.8.10","3.10","3.11","3.12"]
+        python-version: ["3.9.13","3.10","3.11","3.12"] # removed 3.8, it's no longer getting security updates
       fail-fast: false
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ["macos-latest", "windows-latest","ubuntu-20.04"]
+        os: ["macos-latest", "windows-latest","ubuntu-latest"]
         python-version: ["3.9.13","3.8.10","3.10","3.11","3.12"]
       fail-fast: false
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install deutschland
 
 ### Supported Python Versions
 ```
-3.8 - 3.12
+3.9 - 3.12
 ```
 Tested on Linux, MacOS and Windows 
 


### PR DESCRIPTION
This pull request updates GitHub Actions workflows and documentation to align with current best practices and supported Python versions. Key changes include upgrading deprecated actions, expanding Python version testing, and removing unsupported versions.

### Workflow updates:

* [`.github/workflows/doc.yml`](diffhunk://#diff-7871fa1d10e6bf511d9cfda5a6874d1a75acb950fb1bc9fee6057eff13257521L21-R21): Upgraded `actions/upload-artifact` from v3 to v4, as v3 is deprecated.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L11-R11): Expanded the Python version matrix to include `3.9`, `3.10`, `3.11`, and `3.12`, covering the range of supported Python versions.
* [`.github/workflows/runtests.yml`](diffhunk://#diff-9f6c80ea0a9b129bbe2e3f6a192da95fcd503dc043d0b6af673250d9bd2f7546L12-R13): Updated the OS matrix to use `ubuntu-latest` instead of `ubuntu-20.04` and removed Python 3.8 from testing, as it no longer receives security updates.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18): Updated the supported Python versions section to reflect the removal of Python 3.8.